### PR TITLE
Add connection pool with failover and keepalive

### DIFF
--- a/pydeako/__init__.py
+++ b/pydeako/__init__.py
@@ -3,10 +3,17 @@ pydeako module provides the following:
  - models to interact with Deako devices locally with a socket connection
  - implementation of a Deako socket client
  - mdns discovery client
+ - connection pool with failover support
 """
 # pylint: disable=duplicate-code
 from .discover import DeakoDiscoverer, DevicesNotFoundException
-from .deako import Deako, FindDevicesError
+from .deako import (
+    Deako,
+    FindDevicesError,
+    DeakoConnectionPool,
+    ConnectionPoolState,
+    NoSocketException,
+)
 from .models import (
     RequestType,
     ResponseType,
@@ -20,6 +27,9 @@ __all__ = [
     'DevicesNotFoundException',
     'Deako',
     'FindDevicesError',
+    'DeakoConnectionPool',
+    'ConnectionPoolState',
+    'NoSocketException',
     'RequestType',
     'ResponseType',
     'device_list_request',

--- a/pydeako/deako/__init__.py
+++ b/pydeako/deako/__init__.py
@@ -1,8 +1,16 @@
 """Module for controlling deako devices locally."""
 
 from ._deako import Deako, FindDevicesError
+from ._connection_pool import (
+    DeakoConnectionPool,
+    ConnectionPoolState,
+)
+from .utils._socket import NoSocketException
 
 __all__ = [
     'Deako',
     'FindDevicesError',
+    'DeakoConnectionPool',
+    'ConnectionPoolState',
+    'NoSocketException',
 ]

--- a/pydeako/deako/_connection_pool.py
+++ b/pydeako/deako/_connection_pool.py
@@ -34,8 +34,7 @@ _LOGGER: logging.Logger = logging.getLogger(__package__)
 
 # Bridge TCP port used by `_tcp_probe`. The protocol layer parses
 # "ip:port" address strings in utils/_socket.py and exposes no
-# shared port constant, so the pool owns this value at module
-# scope per section 7.
+# shared port constant, so the pool owns this value at module scope.
 DEAKO_DEFAULT_PORT = 23
 
 # Upper bound on waiting for a concurrent switch to complete.
@@ -67,10 +66,11 @@ async def _tcp_probe(
     """Bounded TCP reachability check. Module-private.
 
     Returns True iff a TCP connection to ``host:port`` could be
-    established within ``timeout`` seconds. This is a reachability
-    probe, not a readiness proof; a bridge that answers here may
-    still reject the application-level handshake. Callers follow
-    this with `_connect_primary` as the readiness gate.
+    established within ``timeout`` seconds. A successful TCP accept
+    only proves the port is open—it does not guarantee the bridge is
+    ready to speak the Deako protocol. Callers follow this with
+    ``Deako.connect()`` + ``find_devices()`` (via ``_connect_primary``)
+    as the real readiness gate.
     """
     try:
         _, writer = await asyncio.wait_for(
@@ -98,8 +98,8 @@ class _KeepAliveSocket:
     socket open to the current standby bridge so the bridge is
     warm the instant a failover runs.
 
-    `start()` and `stop()` are both awaitable (decision 24). All
-    pool-level callers wrap `stop()` in
+    `start()` and `stop()` are both awaitable. All pool-level
+    callers wrap `stop()` in
     `asyncio.wait_for(..., timeout=STEP_TIMEOUT_S)` after
     checking that the pool's keepalive reference is non-None.
     """
@@ -118,8 +118,8 @@ class _KeepAliveSocket:
         """Open the keepalive socket.
 
         Raises OSError on connect failure. Pool-level callers treat
-        that failure as non-fatal per decision 27: log WARNING and
-        proceed with `self._keepalive = None`.
+        that failure as non-fatal: log WARNING and proceed with
+        `self._keepalive = None`.
         """
         loop = asyncio.get_running_loop()
         sock = _SocketConnection(self._address, loop)
@@ -152,7 +152,7 @@ class _KeepAliveSocket:
 
 @dataclass(frozen=True)
 class ConnectionPoolState:
-    """Immutable snapshot of the pool's state (decision 23).
+    """Immutable snapshot of the pool's state.
 
     Exactly five fields. Pull-only via `DeakoConnectionPool.state()`.
     `primary_host` and `failover_host` are `str` for the lifetime
@@ -170,18 +170,18 @@ class ConnectionPoolState:
 class DeakoConnectionPool:
     """Primary-failover connection pool for Deako bridges.
 
-    Recovery is caller-driven (decision 19): there is no background
-    health monitor. A failed send on the active primary triggers
-    exactly one `_switch_to_failover` attempt inside the same
-    `control_device` call, plus one retry on the new active. Once
-    the pool enters a degraded state (no connected active), the
-    next `control_device` call runs `_attempt_recovery` which tries
-    both hosts in deterministic order and raises
-    `NoSocketException` with a host-annotated message on failure.
+    Recovery is caller-driven: there is no background health monitor.
+    A failed send on the active primary triggers exactly one
+    `_switch_to_failover` attempt inside the same `control_device`
+    call, plus one retry on the new active. Once the pool enters a
+    degraded state (no connected active), the next `control_device`
+    call runs `_attempt_recovery` which tries both hosts in
+    deterministic order and raises `NoSocketException` with a
+    host-annotated message on failure.
 
-    `stop()` is terminal (decision 22). Calling `start()` after
-    `stop()` raises `RuntimeError`. `control_device()` after
-    `stop()` raises `NoSocketException`.
+    `stop()` is terminal. Calling `start()` after `stop()` raises
+    `RuntimeError`. `control_device()` after `stop()` raises
+    `NoSocketException`.
 
     State callbacks registered via `set_state_callback` are stored
     on the pool itself and replayed onto the new active `Deako`
@@ -216,8 +216,7 @@ class DeakoConnectionPool:
 
         Concurrent `start()` calls on the same pool are unsupported:
         callers must serialize setup. Home Assistant's single-thread
-        async setup satisfies this naturally. This PR does not add a
-        start-lock (decision 9).
+        async setup satisfies this naturally.
         """
         if primary_host == failover_host:
             raise ValueError(
@@ -233,11 +232,11 @@ class DeakoConnectionPool:
         self.active: Deako | None = None
         self._keepalive: _KeepAliveSocket | None = None
 
-        # Pool-owned callback registry (decision 7). Replayed onto
-        # the new active after every successful switch / recovery.
+        # Pool-owned callback registry. Replayed onto the new active
+        # after every successful switch / recovery.
         self._state_callbacks: dict[str, Callable[[], None]] = {}
 
-        # Switch serialization primitives (decision 6 and 20).
+        # Switch serialization primitives.
         self._switch_lock: asyncio.Lock = asyncio.Lock()
         self._switch_event: asyncio.Event = asyncio.Event()
         self._switch_event.set()
@@ -279,8 +278,8 @@ class DeakoConnectionPool:
     def is_connected(self) -> bool:
         """Return True iff the active primary is currently connected.
 
-        Uses `Deako.is_connected()` (decision 21) so the pool does
-        not reach through the manager to check socket state.
+        Uses `Deako.is_connected()` so the pool does not reach
+        through manager internals to check socket state.
         """
         return self.active is not None and self.active.is_connected()
 
@@ -295,8 +294,7 @@ class DeakoConnectionPool:
         onto the new active `Deako` after every successful failover
         switch or recovery, so user callbacks survive bridge swaps
         without re-registration. Callback shape matches
-        `Deako.set_state_callback` (decision 10): sync only, zero
-        arguments. Async callbacks are not supported in this PR.
+        `Deako.set_state_callback`: sync only, zero arguments.
         """
         self._state_callbacks[uuid] = callback
         if self.active is not None:
@@ -345,17 +343,17 @@ class DeakoConnectionPool:
 
         Fail-fast: raises `NoSocketException` if the primary cannot
         be reached. A best-effort `_KeepAliveSocket` is then started
-        on `failover_host`; keepalive failure is non-fatal per
-        decision 27 and leaves `self._keepalive = None`.
+        on `failover_host`; keepalive failure is non-fatal and leaves
+        `self._keepalive = None`.
 
         Idempotent after first success: a subsequent `start()` on
         an already-started pool is a no-op. A failed initial
         `start()` leaves the pool unstarted (`_started=False`,
         `active=None`, `_keepalive=None`) so a later retry can
         succeed normally. `start()` after `stop()` raises
-        `RuntimeError` (decision 22); the pool is single-use.
+        `RuntimeError`; the pool is single-use.
 
-        Concurrent `start()` calls are unsupported (decision 9).
+        Concurrent `start()` calls are unsupported.
         """
         if self._stopped:
             raise RuntimeError(
@@ -374,10 +372,10 @@ class DeakoConnectionPool:
                 f"start: primary {self.primary_host} unreachable: "
                 f"{exc}",
             ) from exc
-        # Post-await stopped re-check (decision 22). If stop() ran
-        # while the long connect was in flight, discard the freshly
-        # connected Deako rather than installing it on a pool the
-        # caller has already terminated.
+        # Post-await stopped re-check. If stop() ran while the long
+        # connect was in flight, discard the freshly connected Deako
+        # rather than installing it on a pool the caller has already
+        # terminated.
         if self._stopped:
             try:
                 await asyncio.wait_for(
@@ -392,13 +390,12 @@ class DeakoConnectionPool:
                 )
             return
         # Primary is live. Latch started BEFORE best-effort keepalive
-        # so a keepalive failure does not un-set it (decision 9 and
-        # decision 27 combined).
+        # so a keepalive failure does not un-set it.
         self.active = new_active
         self._started = True
         # Replay any callbacks that were registered before start().
         self._replay_callbacks(new_active)
-        # Best-effort warm standby on failover_host per decision 27.
+        # Best-effort warm standby on failover_host.
         try:
             await self._start_keepalive(self.failover_host)
         except Exception as exc:  # pylint: disable=broad-exception-caught
@@ -410,16 +407,16 @@ class DeakoConnectionPool:
             self._keepalive = None
 
     async def stop(self) -> None:
-        """Terminal shutdown. Re-entrant-safe (decision 22).
+        """Terminal shutdown. Re-entrant-safe.
 
         Sets `_stopped=True` first so any in-flight switch method
         sees it on its next await boundary and bails out. Sets
         `_switch_event` to unblock any waiters. Then tears down
         the keepalive and the active connection under
-        `asyncio.wait_for(..., timeout=STEP_TIMEOUT_S)` with the
-        unified WARNING wording from decision 24. Each teardown is
-        None-guarded because `stop()` may run before `start()`
-        completed, after a failed recovery, or mid-partial-connect.
+        `asyncio.wait_for(..., timeout=STEP_TIMEOUT_S)`. Each
+        teardown is None-guarded because `stop()` may run before
+        `start()` completed, after a failed recovery, or
+        mid-partial-connect.
         """
         if self._stopped:
             return
@@ -472,8 +469,7 @@ class DeakoConnectionPool:
         for calling `_cleanup_partial_connect` on the partial
         object if one was created. This method never mutates pool
         state beyond returning the new `Deako`; the caller
-        installs it on `self.active` only after success (decision
-        14 host-swap invariant).
+        installs it on `self.active` only after success.
         """
         port = DEAKO_DEFAULT_PORT
         address = f"{host}:{port}"
@@ -535,8 +531,8 @@ class DeakoConnectionPool:
 
         Stores the result in `self._keepalive` on success. Raises
         on failure; all pool-level callers wrap the call in
-        `try/except Exception` per decision 27 and set
-        `self._keepalive = None` on failure.
+        `try/except Exception` and set `self._keepalive = None`
+        on failure.
         """
         keepalive = _KeepAliveSocket(host)
         await keepalive.start()
@@ -609,13 +605,13 @@ class DeakoConnectionPool:
     ) -> bool:
         """Switch the active connection to the failover bridge.
 
-        Section 7.2 contract. Called from the `on_connection_lost`
-        path and from the `control_device` hot-failover path
-        (section 7.4) with `failed_host = self.primary_host`.
+        Called from the `on_connection_lost` path and from the
+        `control_device` hot-failover path with
+        `failed_host = self.primary_host`.
 
         Returns True on success, False on any failure (host not
         ready, connect exhausted, stopped mid-flight). The host
-        map is only mutated on the success branch (decision 14).
+        map is only mutated on the success branch.
 
         The concurrent-caller path waits on `_switch_event` up to
         `SWITCH_WAIT_TIMEOUT_S`; if `failed_host` is None, success
@@ -651,11 +647,10 @@ class DeakoConnectionPool:
                 # Step 4: stopped check.
                 if self._stopped:
                     return False
-                # Step 6: release warm-standby keepalive. The pool's
-                # own keepalive lives on failover_host, and we are
-                # about to connect there; without this it fights us
-                # for the single TCP slot on that bridge. None-guard
-                # is defensive per section 7.2 note.
+                # Release the standby keepalive before connecting.
+                # The bridge only accepts one TCP session, so the
+                # keepalive must be dropped first or it blocks the
+                # real Deako connection to the failover host.
                 if self._keepalive is not None:
                     try:
                         await asyncio.wait_for(
@@ -703,10 +698,10 @@ class DeakoConnectionPool:
                         "switch: connect_exhausted on %s", target,
                     )
                     return False
-                # Step 11: post-await stopped re-check (decision 22).
-                # If stop() ran while _connect_with_retry was in
-                # flight, discard the freshly connected Deako and
-                # bail without mutating the host map.
+                # Post-await stopped re-check. If stop() ran while
+                # _connect_with_retry was in flight, discard the
+                # freshly connected Deako and bail without mutating
+                # the host map.
                 if self._stopped:
                     try:
                         await asyncio.wait_for(
@@ -773,7 +768,7 @@ class DeakoConnectionPool:
     def _fire_on_failover_switch(self) -> None:
         """Invoke the user switch callback, swallowing errors.
 
-        Sync-only per decision 10. Callback errors are logged at
+        Sync-only. Callback errors are logged at
         WARNING so they never destabilize the pool.
         """
         if self._on_failover_switch is None:
@@ -793,13 +788,12 @@ class DeakoConnectionPool:
     ) -> tuple[bool, dict[str, str]]:
         """Two-host recovery path used only by the no-primary send.
 
-        Section 7.3 contract. Returns `(True, {})` on success and
-        `(False, reasons)` on failure, where `reasons` maps each
-        host to its last reason token (`tcp_probe_failed`,
-        `connect_exhausted`, `stopped`, `switch_wait_timeout`, or
-        `in_flight_switch_failed`). The section 7.5 message
-        builder uses the reasons dict to name the hosts and their
-        failure causes in the raised `NoSocketException`.
+        Returns `(True, {})` on success and `(False, reasons)` on
+        failure, where `reasons` maps each host to its last reason
+        token (`tcp_probe_failed`, `connect_exhausted`, `stopped`,
+        `switch_wait_timeout`, or `in_flight_switch_failed`).
+        `_ensure_primary_or_raise` uses the reasons dict to build
+        the host-annotated `NoSocketException` message.
 
         Probe order is deterministic: `self.primary_host` first,
         `self.failover_host` second. The winner becomes the new
@@ -813,7 +807,7 @@ class DeakoConnectionPool:
                 self.failover_host: token,
             }
 
-        # Concurrent-caller path per section 7.3.
+        # Concurrent-caller path.
         if self._switch_lock.locked():
             try:
                 await asyncio.wait_for(
@@ -834,9 +828,9 @@ class DeakoConnectionPool:
             try:
                 if self._stopped:
                     return False, _fill_both("stopped")
-                # Decision 28: disconnect any stale half-dead
-                # `self.active` before probing so it cannot
-                # compete with the new connection.
+                # Disconnect any stale half-dead `self.active`
+                # before probing so it cannot compete with the
+                # new connection.
                 if self.active is not None:
                     try:
                         await asyncio.wait_for(
@@ -850,9 +844,9 @@ class DeakoConnectionPool:
                             STEP_TIMEOUT_S,
                         )
                     self.active = None
-                # Decision 26: release the warm-standby keepalive
-                # before any probe so recovery does not fight its
-                # own socket on failover_host.
+                # Release the standby keepalive before probing. The
+                # bridge only accepts one TCP session, so recovery
+                # must not fight its own keepalive socket.
                 if self._keepalive is not None:
                     try:
                         await asyncio.wait_for(
@@ -886,10 +880,10 @@ class DeakoConnectionPool:
                             return False, _fill_both("stopped")
                         reasons[target] = "connect_exhausted"
                         continue
-                    # Post-await stopped re-check (decision 22). If
-                    # stop() ran while _connect_with_retry was in
-                    # flight, discard the freshly connected Deako
-                    # and bail without mutating the host map.
+                    # Post-await stopped re-check. If stop() ran
+                    # while _connect_with_retry was in flight,
+                    # discard the freshly connected Deako and bail
+                    # without mutating the host map.
                     if self._stopped:
                         try:
                             await asyncio.wait_for(
@@ -938,9 +932,9 @@ class DeakoConnectionPool:
     # ----- control_device send path ----------------------------
 
     async def _ensure_primary_or_raise(self) -> None:
-        """Section 7.5: if no connected primary, run recovery.
+        """If no connected primary, run recovery.
 
-        Raises `NoSocketException` with the decision-25 message
+        Raises `NoSocketException` with a host-annotated message
         on recovery failure. Called from `control_device` when
         `self.active` is None or not connected.
         """
@@ -969,10 +963,9 @@ class DeakoConnectionPool:
     ) -> None:
         """Send a device control command through the active pool.
 
-        Section 7.4 hot-failover path plus section 7.5 no-primary
-        path. The pool calls `Deako._control_device_strict` (not
-        the public `control_device`) so it sees the raising
-        contract from decision 29 and can drive failover.
+        The pool calls `Deako._control_device_strict` (not the
+        public `control_device`) so send failures raise instead
+        of being swallowed, letting the pool drive failover.
 
         On `OSError` or `NoSocketException` from the active send,
         performs exactly one `_switch_to_failover(failed_host=
@@ -980,12 +973,12 @@ class DeakoConnectionPool:
         send on the new active. If the switch returns False, or
         the retry raises, raises `NoSocketException` naming the
         host(s) attempted. Does not cascade into
-        `_attempt_recovery`; the next call enters section 7.5 and
-        runs recovery naturally.
+        `_attempt_recovery`; the next call enters the no-primary
+        path and runs recovery naturally.
         """
         if self._stopped:
             raise NoSocketException("pool stopped")
-        # Section 7.5: no connected primary -> run recovery.
+        # No connected primary -> run recovery.
         if (
             self.active is None
             or not self.active.is_connected()
@@ -1001,7 +994,7 @@ class DeakoConnectionPool:
             )
             return
         except OSError:
-            # NoSocketException subclasses OSError per decision 17.
+            # NoSocketException subclasses OSError.
             _LOGGER.warning(
                 "control_device send failed on active primary "
                 "%s; switching to failover",

--- a/pydeako/deako/_connection_pool.py
+++ b/pydeako/deako/_connection_pool.py
@@ -20,6 +20,7 @@ that want a fresh pool must construct a new one. Host names
 pool and never nulled out on any path; degraded state is signaled
 through `ConnectionPoolState`, not missing host fields.
 """
+# pylint: disable=too-many-lines
 
 import asyncio
 import logging
@@ -218,6 +219,12 @@ class DeakoConnectionPool:
         async setup satisfies this naturally. This PR does not add a
         start-lock (decision 9).
         """
+        if primary_host == failover_host:
+            raise ValueError(
+                "DeakoConnectionPool: primary_host and "
+                "failover_host must be distinct; use Deako "
+                "directly for single-bridge setups",
+            )
         self.primary_host: str = primary_host
         self.failover_host: str = failover_host
         self._client_name = client_name
@@ -367,6 +374,23 @@ class DeakoConnectionPool:
                 f"start: primary {self.primary_host} unreachable: "
                 f"{exc}",
             ) from exc
+        # Post-await stopped re-check (decision 22). If stop() ran
+        # while the long connect was in flight, discard the freshly
+        # connected Deako rather than installing it on a pool the
+        # caller has already terminated.
+        if self._stopped:
+            try:
+                await asyncio.wait_for(
+                    new_active.disconnect(),
+                    timeout=STEP_TIMEOUT_S,
+                )
+            except asyncio.TimeoutError:
+                _LOGGER.warning(
+                    "active.disconnect() timed out after %ss; "
+                    "proceeding",
+                    STEP_TIMEOUT_S,
+                )
+            return
         # Primary is live. Latch started BEFORE best-effort keepalive
         # so a keepalive failure does not un-set it (decision 9 and
         # decision 27 combined).
@@ -679,6 +703,23 @@ class DeakoConnectionPool:
                         "switch: connect_exhausted on %s", target,
                     )
                     return False
+                # Step 11: post-await stopped re-check (decision 22).
+                # If stop() ran while _connect_with_retry was in
+                # flight, discard the freshly connected Deako and
+                # bail without mutating the host map.
+                if self._stopped:
+                    try:
+                        await asyncio.wait_for(
+                            new_active.disconnect(),
+                            timeout=STEP_TIMEOUT_S,
+                        )
+                    except asyncio.TimeoutError:
+                        _LOGGER.warning(
+                            "active.disconnect() timed out after"
+                            " %ss; proceeding",
+                            STEP_TIMEOUT_S,
+                        )
+                    return False
                 # Step 12: success. Swap host map, install new
                 # active, replay callbacks, start keepalive best
                 # effort on the former primary.
@@ -746,7 +787,7 @@ class DeakoConnectionPool:
                 "on_failover_switch callback error: %s", exc,
             )
 
-    # pylint: disable-next=too-many-return-statements,too-many-branches
+    # pylint: disable-next=too-many-return-statements,too-many-branches,too-many-statements
     async def _attempt_recovery(
         self,
     ) -> tuple[bool, dict[str, str]]:
@@ -845,6 +886,23 @@ class DeakoConnectionPool:
                             return False, _fill_both("stopped")
                         reasons[target] = "connect_exhausted"
                         continue
+                    # Post-await stopped re-check (decision 22). If
+                    # stop() ran while _connect_with_retry was in
+                    # flight, discard the freshly connected Deako
+                    # and bail without mutating the host map.
+                    if self._stopped:
+                        try:
+                            await asyncio.wait_for(
+                                new_deako.disconnect(),
+                                timeout=STEP_TIMEOUT_S,
+                            )
+                        except asyncio.TimeoutError:
+                            _LOGGER.warning(
+                                "active.disconnect() timed out "
+                                "after %ss; proceeding",
+                                STEP_TIMEOUT_S,
+                            )
+                        return False, _fill_both("stopped")
                     # Success on this target.
                     self.active = new_deako
                     self._replay_callbacks(new_deako)

--- a/pydeako/deako/_connection_pool.py
+++ b/pydeako/deako/_connection_pool.py
@@ -1,0 +1,978 @@
+"""
+Connection pool for Deako bridges with primary/failover support.
+
+Manages two bridge connections:
+  - An active primary Deako used for live device commands.
+  - A standby bridge held warm by a single TCP keepalive socket so
+    that a failover switch does not have to wait for the bridge to
+    leave idle mode.
+
+Recovery is caller-driven. There is no background health monitor and
+no periodic task. The `control_device()` send path triggers at most
+one failover switch per call on a real send failure; once the pool
+is in a degraded state the next `control_device()` call invokes a
+two-host recovery routine that probes and connects to
+`primary_host` first, then `failover_host`.
+
+`stop()` is terminal. A stopped pool is not restartable. Callers
+that want a fresh pool must construct a new one. Host names
+(`primary_host`, `failover_host`) are `str` for the lifetime of the
+pool and never nulled out on any path; degraded state is signaled
+through `ConnectionPoolState`, not missing host fields.
+"""
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import Callable
+
+from ._deako import Deako
+from .utils._socket import NoSocketException, _SocketConnection
+
+_LOGGER: logging.Logger = logging.getLogger(__package__)
+
+# Bridge TCP port used by `_tcp_probe`. The protocol layer parses
+# "ip:port" address strings in utils/_socket.py and exposes no
+# shared port constant, so the pool owns this value at module
+# scope per section 7.
+DEAKO_DEFAULT_PORT = 23
+
+# Upper bound on waiting for a concurrent switch to complete.
+SWITCH_WAIT_TIMEOUT_S = 10.0
+
+# Bounded connect-with-retry budget used by `_switch_to_failover`
+# and `_attempt_recovery`.
+SWITCH_CONNECT_RETRIES = 3
+SWITCH_CONNECT_BACKOFF_S = 1.0
+
+# Upper bound on `_wait_ready` for the failover host to accept
+# TCP connections after a recycle.
+BRIDGE_RECYCLE_TIMEOUT_S = 10.0
+
+# Upper bound on a single `_tcp_probe` call.
+PROBE_TIMEOUT = 3.0
+
+# Per-step teardown bound applied to `keepalive.stop()` and
+# `active.disconnect()` in `stop()`, `_switch_to_failover`, and
+# `_attempt_recovery`. Small on purpose: teardown never waits long.
+STEP_TIMEOUT_S = 2.0
+
+
+async def _tcp_probe(
+    host: str,
+    port: int = DEAKO_DEFAULT_PORT,
+    timeout: float = PROBE_TIMEOUT,
+) -> bool:
+    """Bounded TCP reachability check. Module-private.
+
+    Returns True iff a TCP connection to ``host:port`` could be
+    established within ``timeout`` seconds. This is a reachability
+    probe, not a readiness proof; a bridge that answers here may
+    still reject the application-level handshake. Callers follow
+    this with `_connect_primary` as the readiness gate.
+    """
+    try:
+        _, writer = await asyncio.wait_for(
+            asyncio.open_connection(host, port),
+            timeout=timeout,
+        )
+    except (OSError, asyncio.TimeoutError):
+        return False
+    try:
+        writer.close()
+        try:
+            await writer.wait_closed()
+        except OSError:
+            pass
+    except OSError:
+        pass
+    return True
+
+
+class _KeepAliveSocket:
+    """Raw TCP socket held open to a Deako bridge.
+
+    A Deako bridge stays in WiFi-relay mode as long as some TCP
+    connection is held open on port 23. The pool keeps one such
+    socket open to the current standby bridge so the bridge is
+    warm the instant a failover runs.
+
+    `start()` and `stop()` are both awaitable (decision 24). All
+    pool-level callers wrap `stop()` in
+    `asyncio.wait_for(..., timeout=STEP_TIMEOUT_S)` after
+    checking that the pool's keepalive reference is non-None.
+    """
+
+    def __init__(
+        self, host: str, port: int = DEAKO_DEFAULT_PORT,
+    ) -> None:
+        """Record target host and port without opening anything."""
+        self.host = host
+        self.port = port
+        self._address = f"{host}:{port}"
+        self._socket: _SocketConnection | None = None
+        self._running = False
+
+    async def start(self) -> None:
+        """Open the keepalive socket.
+
+        Raises OSError on connect failure. Pool-level callers treat
+        that failure as non-fatal per decision 27: log WARNING and
+        proceed with `self._keepalive = None`.
+        """
+        loop = asyncio.get_running_loop()
+        sock = _SocketConnection(self._address, loop)
+        await sock.connect_socket()
+        self._socket = sock
+        self._running = True
+
+    async def stop(self) -> None:
+        """Close the keepalive socket. Always safe to await.
+
+        Idempotent: a second call after the first is a no-op.
+        Awaitable so pool-level callers can wrap the call in
+        `asyncio.wait_for` with `STEP_TIMEOUT_S`. The inner
+        `_SocketConnection.close_socket` is a synchronous system
+        call with no waitable work today, but the async signature
+        is part of the pool contract and lets the inner call add
+        awaitable teardown later without changing call sites.
+        """
+        self._running = False
+        if self._socket is not None:
+            self._socket.close_socket()
+            self._socket = None
+
+    def is_running(self) -> bool:
+        """Return True iff the keepalive is currently held open."""
+        if not self._running or self._socket is None:
+            return False
+        return self._socket.sock is not None
+
+
+@dataclass(frozen=True)
+class ConnectionPoolState:
+    """Immutable snapshot of the pool's state (decision 23).
+
+    Exactly five fields. Pull-only via `DeakoConnectionPool.state()`.
+    `primary_host` and `failover_host` are `str` for the lifetime
+    of the pool and are never set to None on any code path; degraded
+    state is represented by the boolean flags.
+    """
+
+    primary_host: str
+    failover_host: str
+    primary_connected: bool
+    failover_keepalive_active: bool
+    started: bool
+
+
+class DeakoConnectionPool:
+    """Primary-failover connection pool for Deako bridges.
+
+    Recovery is caller-driven (decision 19): there is no background
+    health monitor. A failed send on the active primary triggers
+    exactly one `_switch_to_failover` attempt inside the same
+    `control_device` call, plus one retry on the new active. Once
+    the pool enters a degraded state (no connected active), the
+    next `control_device` call runs `_attempt_recovery` which tries
+    both hosts in deterministic order and raises
+    `NoSocketException` with a host-annotated message on failure.
+
+    `stop()` is terminal (decision 22). Calling `start()` after
+    `stop()` raises `RuntimeError`. `control_device()` after
+    `stop()` raises `NoSocketException`.
+
+    State callbacks registered via `set_state_callback` are stored
+    on the pool itself and replayed onto the new active `Deako`
+    after every successful switch or recovery, so user callbacks
+    survive bridge failover without re-registration.
+    """
+
+    # pylint: disable=too-many-instance-attributes
+    active: Deako | None
+
+    def __init__(
+        self,
+        primary_host: str,
+        failover_host: str,
+        client_name: str | None = None,
+        on_failover_switch: Callable[[str, str], None] | None = None,
+    ) -> None:
+        """Initialize the pool.
+
+        Args:
+            primary_host: IP address of the primary bridge. Required.
+            failover_host: IP address of the failover bridge. Required;
+                this PR does not support single-bridge pools (use
+                `Deako` directly for that).
+            client_name: Optional client name sent in protocol
+                messages; forwarded to every `Deako` the pool owns.
+            on_failover_switch: Optional sync callback invoked after
+                a successful switch or recovery with the new primary
+                host and the new failover host. Exceptions raised by
+                the callback are logged at WARNING and swallowed so
+                they never destabilize the pool.
+
+        Concurrent `start()` calls on the same pool are unsupported:
+        callers must serialize setup. Home Assistant's single-thread
+        async setup satisfies this naturally. This PR does not add a
+        start-lock (decision 9).
+        """
+        self.primary_host: str = primary_host
+        self.failover_host: str = failover_host
+        self._client_name = client_name
+        self._on_failover_switch = on_failover_switch
+
+        self.active: Deako | None = None
+        self._keepalive: _KeepAliveSocket | None = None
+
+        # Pool-owned callback registry (decision 7). Replayed onto
+        # the new active after every successful switch / recovery.
+        self._state_callbacks: dict[str, Callable[[], None]] = {}
+
+        # Switch serialization primitives (decision 6 and 20).
+        self._switch_lock: asyncio.Lock = asyncio.Lock()
+        self._switch_event: asyncio.Event = asyncio.Event()
+        self._switch_event.set()
+
+        self._started: bool = False
+        self._stopped: bool = False
+
+        # Scratch reference for `_cleanup_partial_connect`, populated
+        # by `_connect_primary` while a connect is in flight and
+        # cleared on success. Defined in __init__ so pylint is happy
+        # and the attribute exists even if a caller invokes
+        # `_cleanup_partial_connect` before any connect attempt.
+        self._partial_deako: Deako | None = None
+
+        # Tasks scheduled by `_on_active_connection_lost` when the
+        # Manager's ping-timeout fires on the active. Held so asyncio
+        # does not GC them mid-switch; discarded on completion.
+        self._on_lost_tasks: set[asyncio.Task] = set()
+
+    # ----- Observability ---------------------------------------
+
+    def state(self) -> ConnectionPoolState:
+        """Return an immutable snapshot of pool state."""
+        primary_connected = (
+            self.active is not None and self.active.is_connected()
+        )
+        keepalive_active = (
+            self._keepalive is not None
+            and self._keepalive.is_running()
+        )
+        return ConnectionPoolState(
+            primary_host=self.primary_host,
+            failover_host=self.failover_host,
+            primary_connected=primary_connected,
+            failover_keepalive_active=keepalive_active,
+            started=self._started and not self._stopped,
+        )
+
+    def is_connected(self) -> bool:
+        """Return True iff the active primary is currently connected.
+
+        Uses `Deako.is_connected()` (decision 21) so the pool does
+        not reach through the manager to check socket state.
+        """
+        return self.active is not None and self.active.is_connected()
+
+    # ----- State callbacks -------------------------------------
+
+    def set_state_callback(
+        self, uuid: str, callback: Callable[[], None],
+    ) -> None:
+        """Register a sync state-change callback for a device.
+
+        The callback is stored on the pool and automatically replayed
+        onto the new active `Deako` after every successful failover
+        switch or recovery, so user callbacks survive bridge swaps
+        without re-registration. Callback shape matches
+        `Deako.set_state_callback` (decision 10): sync only, zero
+        arguments. Async callbacks are not supported in this PR.
+        """
+        self._state_callbacks[uuid] = callback
+        if self.active is not None:
+            self.active.set_state_callback(uuid, callback)
+
+    def _replay_callbacks(self, deako: Deako) -> None:
+        """Register all stored callbacks on a fresh `Deako`.
+
+        Called on the success path of `_switch_to_failover` and
+        `_attempt_recovery` so the new active picks up every
+        previously-registered state-change listener.
+        """
+        for uuid, callback in self._state_callbacks.items():
+            deako.set_state_callback(uuid, callback)
+
+    # ----- Device accessors (proxied to active) ----------------
+
+    def get_devices(self) -> dict:
+        """Return known devices from the active connection, or {}."""
+        if self.active is None:
+            return {}
+        return self.active.get_devices()
+
+    def get_state(self, uuid: str) -> dict | None:
+        """Get a device's state from the active connection."""
+        if self.active is None:
+            return None
+        return self.active.get_state(uuid)
+
+    def get_name(self, uuid: str) -> str | None:
+        """Get a device's name from the active connection."""
+        if self.active is None:
+            return None
+        return self.active.get_name(uuid)
+
+    def is_dimmable(self, uuid: str) -> bool | None:
+        """Return whether a device is dimmable, via active."""
+        if self.active is None:
+            return None
+        return self.active.is_dimmable(uuid)
+
+    # ----- Lifecycle -------------------------------------------
+
+    async def start(self) -> None:
+        """Connect to the primary and attach a warm standby.
+
+        Fail-fast: raises `NoSocketException` if the primary cannot
+        be reached. A best-effort `_KeepAliveSocket` is then started
+        on `failover_host`; keepalive failure is non-fatal per
+        decision 27 and leaves `self._keepalive = None`.
+
+        Idempotent after first success: a subsequent `start()` on
+        an already-started pool is a no-op. A failed initial
+        `start()` leaves the pool unstarted (`_started=False`,
+        `active=None`, `_keepalive=None`) so a later retry can
+        succeed normally. `start()` after `stop()` raises
+        `RuntimeError` (decision 22); the pool is single-use.
+
+        Concurrent `start()` calls are unsupported (decision 9).
+        """
+        if self._stopped:
+            raise RuntimeError(
+                "DeakoConnectionPool: start() after stop() is not "
+                "supported; construct a new pool",
+            )
+        if self._started:
+            return
+        # Connect primary first. Failure is fatal to start().
+        try:
+            new_active = await self._connect_primary(self.primary_host)
+        except (OSError, NoSocketException) as exc:
+            # Leave the pool unstarted so a retry may succeed.
+            await self._cleanup_partial_connect()
+            raise NoSocketException(
+                f"start: primary {self.primary_host} unreachable: "
+                f"{exc}",
+            ) from exc
+        # Primary is live. Latch started BEFORE best-effort keepalive
+        # so a keepalive failure does not un-set it (decision 9 and
+        # decision 27 combined).
+        self.active = new_active
+        self._started = True
+        # Replay any callbacks that were registered before start().
+        self._replay_callbacks(new_active)
+        # Best-effort warm standby on failover_host per decision 27.
+        try:
+            await self._start_keepalive(self.failover_host)
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            _LOGGER.warning(
+                "keepalive start on %s failed at start: %s; "
+                "pool proceeds without warm standby",
+                self.failover_host, exc,
+            )
+            self._keepalive = None
+
+    async def stop(self) -> None:
+        """Terminal shutdown. Re-entrant-safe (decision 22).
+
+        Sets `_stopped=True` first so any in-flight switch method
+        sees it on its next await boundary and bails out. Sets
+        `_switch_event` to unblock any waiters. Then tears down
+        the keepalive and the active connection under
+        `asyncio.wait_for(..., timeout=STEP_TIMEOUT_S)` with the
+        unified WARNING wording from decision 24. Each teardown is
+        None-guarded because `stop()` may run before `start()`
+        completed, after a failed recovery, or mid-partial-connect.
+        """
+        if self._stopped:
+            return
+        self._stopped = True
+        # Release any waiters on the switch completion event.
+        self._switch_event.set()
+        # Cancel any switch task scheduled by a stale
+        # `_on_active_connection_lost` firing. Tasks discard
+        # themselves on completion so this collection only drains
+        # those still in flight.
+        for task in list(self._on_lost_tasks):
+            task.cancel()
+        self._on_lost_tasks.clear()
+        if self._keepalive is not None:
+            try:
+                await asyncio.wait_for(
+                    self._keepalive.stop(),
+                    timeout=STEP_TIMEOUT_S,
+                )
+            except asyncio.TimeoutError:
+                _LOGGER.warning(
+                    "keepalive.stop() timed out after %ss; "
+                    "proceeding",
+                    STEP_TIMEOUT_S,
+                )
+            self._keepalive = None
+        if self.active is not None:
+            try:
+                await asyncio.wait_for(
+                    self.active.disconnect(),
+                    timeout=STEP_TIMEOUT_S,
+                )
+            except asyncio.TimeoutError:
+                _LOGGER.warning(
+                    "active.disconnect() timed out after %ss; "
+                    "proceeding",
+                    STEP_TIMEOUT_S,
+                )
+            self.active = None
+
+    # ----- Connect helpers -------------------------------------
+
+    async def _connect_primary(self, host: str) -> Deako:
+        """Open and populate a fresh `Deako` on ``host``.
+
+        Used by `start()`, `_switch_to_failover`, and
+        `_attempt_recovery`. Creates a `Deako`, awaits its
+        connect, and calls `find_devices` to populate the device
+        cache. Raises on any failure; the caller is responsible
+        for calling `_cleanup_partial_connect` on the partial
+        object if one was created. This method never mutates pool
+        state beyond returning the new `Deako`; the caller
+        installs it on `self.active` only after success (decision
+        14 host-swap invariant).
+        """
+        port = DEAKO_DEFAULT_PORT
+        address = f"{host}:{port}"
+        client = self._client_name or "pydeako"
+
+        async def get_address():
+            return address, client
+
+        deako = Deako(
+            get_address,
+            client_name=self._client_name,
+            on_connection_lost=self._on_active_connection_lost,
+        )
+        # The pool owns reconnect via failover; disable the Manager's
+        # built-in auto_reconnect so it cannot race the pool by
+        # reopening the same host while a switch is in flight.
+        deako.connection_manager.auto_reconnect = False
+        # Track the in-progress object so a mid-connect failure can
+        # be cleaned up. The caller invokes
+        # `_cleanup_partial_connect()` on any raise to tear it down.
+        self._partial_deako = deako
+        await deako.connect()
+        await deako.find_devices()
+        self._partial_deako = None
+        return deako
+
+    async def _cleanup_partial_connect(self) -> None:
+        """Tear down a half-initialized `Deako` from `_connect_primary`.
+
+        Called from the caller of `_connect_primary` after any raise.
+        Defensive None-guard: the partial reference may not exist
+        (e.g. `start()` failed before `_connect_primary` was even
+        called). Disconnect under `asyncio.wait_for` with
+        `STEP_TIMEOUT_S`; swallow `TimeoutError` with the unified
+        warning wording.
+        """
+        partial = self._partial_deako
+        if partial is None:
+            return
+        self._partial_deako = None
+        try:
+            await asyncio.wait_for(
+                partial.disconnect(), timeout=STEP_TIMEOUT_S,
+            )
+        except asyncio.TimeoutError:
+            _LOGGER.warning(
+                "active.disconnect() timed out after %ss; "
+                "proceeding",
+                STEP_TIMEOUT_S,
+            )
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            _LOGGER.debug(
+                "partial-connect cleanup error on disconnect: %s",
+                exc,
+            )
+
+    async def _start_keepalive(self, host: str) -> None:
+        """Open a fresh `_KeepAliveSocket` to ``host``.
+
+        Stores the result in `self._keepalive` on success. Raises
+        on failure; all pool-level callers wrap the call in
+        `try/except Exception` per decision 27 and set
+        `self._keepalive = None` on failure.
+        """
+        keepalive = _KeepAliveSocket(host)
+        await keepalive.start()
+        self._keepalive = keepalive
+
+    async def _wait_ready(
+        self,
+        host: str,
+        timeout: float = BRIDGE_RECYCLE_TIMEOUT_S,
+    ) -> bool:
+        """Bounded poll: return True once the host accepts TCP.
+
+        Used by `_switch_to_failover` step 9 to wait out the brief
+        window where the failover bridge is transitioning from
+        standby into active mode. Short-circuits on `_stopped`.
+        """
+        async def _poll() -> bool:
+            while True:
+                if self._stopped:
+                    return False
+                if await _tcp_probe(
+                    host, DEAKO_DEFAULT_PORT, PROBE_TIMEOUT,
+                ):
+                    return True
+                await asyncio.sleep(1.0)
+
+        try:
+            return await asyncio.wait_for(_poll(), timeout=timeout)
+        except asyncio.TimeoutError:
+            return False
+
+    # ----- on_connection_lost hook -----------------------------
+
+    def _on_active_connection_lost(self) -> None:
+        """Sync callback wired onto every active `Deako`.
+
+        Invoked by `_Manager.maintain_connection_worker` when the
+        ping-timeout path fires. Schedules one
+        `_switch_to_failover` task with `failed_host` set to the
+        current primary. The concurrent-caller path inside
+        `_switch_to_failover` handles re-entry if another switch
+        is already running.
+        """
+        if self._stopped:
+            return
+        failed = self.primary_host
+        try:
+            task = asyncio.create_task(
+                self._switch_to_failover(failed_host=failed),
+            )
+        except RuntimeError:
+            # Called from a context with no running loop; this
+            # can happen in edge cases during shutdown. Swallow
+            # so the Manager worker is not destabilized by a
+            # raise inside the sync callback.
+            _LOGGER.debug(
+                "no running loop when scheduling switch for %s; "
+                "ignoring",
+                failed,
+            )
+            return
+        self._on_lost_tasks.add(task)
+        task.add_done_callback(self._on_lost_tasks.discard)
+
+    # ----- Switch and recovery ---------------------------------
+
+    # pylint: disable-next=too-many-return-statements,too-many-branches
+    async def _switch_to_failover(
+        self, failed_host: str | None,
+    ) -> bool:
+        """Switch the active connection to the failover bridge.
+
+        Section 7.2 contract. Called from the `on_connection_lost`
+        path and from the `control_device` hot-failover path
+        (section 7.4) with `failed_host = self.primary_host`.
+
+        Returns True on success, False on any failure (host not
+        ready, connect exhausted, stopped mid-flight). The host
+        map is only mutated on the success branch (decision 14).
+
+        The concurrent-caller path waits on `_switch_event` up to
+        `SWITCH_WAIT_TIMEOUT_S`; if `failed_host` is None, success
+        is determined by actual connected state of the new active,
+        otherwise by whether the primary has moved off
+        `failed_host`.
+        """
+        # Step 1: concurrent-caller path.
+        if self._switch_lock.locked():
+            try:
+                await asyncio.wait_for(
+                    self._switch_event.wait(),
+                    timeout=SWITCH_WAIT_TIMEOUT_S,
+                )
+            except asyncio.TimeoutError:
+                return False
+            if failed_host is None:
+                return (
+                    self.active is not None
+                    and self.active.is_connected()
+                )
+            return self.primary_host != failed_host
+
+        async with self._switch_lock:
+            self._switch_event.clear()
+            try:
+                # Step 3: stale-host guard.
+                if (
+                    failed_host is not None
+                    and failed_host != self.primary_host
+                ):
+                    return True
+                # Step 4: stopped check.
+                if self._stopped:
+                    return False
+                # Step 6: release warm-standby keepalive. The pool's
+                # own keepalive lives on failover_host, and we are
+                # about to connect there; without this it fights us
+                # for the single TCP slot on that bridge. None-guard
+                # is defensive per section 7.2 note.
+                if self._keepalive is not None:
+                    try:
+                        await asyncio.wait_for(
+                            self._keepalive.stop(),
+                            timeout=STEP_TIMEOUT_S,
+                        )
+                    except asyncio.TimeoutError:
+                        _LOGGER.warning(
+                            "keepalive.stop() timed out after %ss;"
+                            " proceeding",
+                            STEP_TIMEOUT_S,
+                        )
+                    self._keepalive = None
+                # Step 7: disconnect the failed active.
+                if self.active is not None:
+                    try:
+                        await asyncio.wait_for(
+                            self.active.disconnect(),
+                            timeout=STEP_TIMEOUT_S,
+                        )
+                    except asyncio.TimeoutError:
+                        _LOGGER.warning(
+                            "active.disconnect() timed out after"
+                            " %ss; proceeding",
+                            STEP_TIMEOUT_S,
+                        )
+                    self.active = None
+                # Step 8: stopped check.
+                if self._stopped:
+                    return False
+                # Step 9: wait for failover host to accept TCP.
+                target = self.failover_host
+                ready = await self._wait_ready(
+                    target, timeout=BRIDGE_RECYCLE_TIMEOUT_S,
+                )
+                if not ready:
+                    _LOGGER.warning(
+                        "switch: host_not_ready on %s", target,
+                    )
+                    return False
+                # Step 10: bounded connect-with-retry.
+                new_active = await self._connect_with_retry(target)
+                if new_active is None:
+                    _LOGGER.warning(
+                        "switch: connect_exhausted on %s", target,
+                    )
+                    return False
+                # Step 12: success. Swap host map, install new
+                # active, replay callbacks, start keepalive best
+                # effort on the former primary.
+                old_primary = self.primary_host
+                self.primary_host = target
+                self.failover_host = old_primary
+                self.active = new_active
+                self._replay_callbacks(new_active)
+                try:
+                    await self._start_keepalive(self.failover_host)
+                # pylint: disable-next=broad-exception-caught
+                except Exception as exc:
+                    _LOGGER.warning(
+                        "keepalive start on %s failed after "
+                        "switch: %s; pool proceeds without warm "
+                        "standby",
+                        self.failover_host, exc,
+                    )
+                    self._keepalive = None
+                _LOGGER.info(
+                    "failover switch succeeded: primary=%s "
+                    "failover=%s",
+                    self.primary_host, self.failover_host,
+                )
+                self._fire_on_failover_switch()
+                return True
+            finally:
+                self._switch_event.set()
+
+    async def _connect_with_retry(self, host: str) -> Deako | None:
+        """Bounded connect loop used by switch and recovery.
+
+        Tries up to `SWITCH_CONNECT_RETRIES + 1` times with
+        `SWITCH_CONNECT_BACKOFF_S` between attempts. Each failed
+        attempt runs `_cleanup_partial_connect` so we never leave
+        a half-constructed Deako behind. Returns the new Deako on
+        success, or None on exhaustion / stopped.
+        """
+        for attempt in range(SWITCH_CONNECT_RETRIES + 1):
+            if self._stopped:
+                return None
+            try:
+                return await self._connect_primary(host)
+            except Exception:  # pylint: disable=broad-exception-caught
+                await self._cleanup_partial_connect()
+                if attempt == SWITCH_CONNECT_RETRIES:
+                    return None
+                await asyncio.sleep(SWITCH_CONNECT_BACKOFF_S)
+        return None
+
+    def _fire_on_failover_switch(self) -> None:
+        """Invoke the user switch callback, swallowing errors.
+
+        Sync-only per decision 10. Callback errors are logged at
+        WARNING so they never destabilize the pool.
+        """
+        if self._on_failover_switch is None:
+            return
+        try:
+            self._on_failover_switch(
+                self.primary_host, self.failover_host,
+            )
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            _LOGGER.warning(
+                "on_failover_switch callback error: %s", exc,
+            )
+
+    # pylint: disable-next=too-many-return-statements,too-many-branches
+    async def _attempt_recovery(
+        self,
+    ) -> tuple[bool, dict[str, str]]:
+        """Two-host recovery path used only by the no-primary send.
+
+        Section 7.3 contract. Returns `(True, {})` on success and
+        `(False, reasons)` on failure, where `reasons` maps each
+        host to its last reason token (`tcp_probe_failed`,
+        `connect_exhausted`, `stopped`, `switch_wait_timeout`, or
+        `in_flight_switch_failed`). The section 7.5 message
+        builder uses the reasons dict to name the hosts and their
+        failure causes in the raised `NoSocketException`.
+
+        Probe order is deterministic: `self.primary_host` first,
+        `self.failover_host` second. The winner becomes the new
+        active; the loser becomes the warm standby.
+        """
+        reasons: dict[str, str] = {}
+
+        def _fill_both(token: str) -> dict[str, str]:
+            return {
+                self.primary_host: token,
+                self.failover_host: token,
+            }
+
+        # Concurrent-caller path per section 7.3.
+        if self._switch_lock.locked():
+            try:
+                await asyncio.wait_for(
+                    self._switch_event.wait(),
+                    timeout=SWITCH_WAIT_TIMEOUT_S,
+                )
+            except asyncio.TimeoutError:
+                return False, _fill_both("switch_wait_timeout")
+            if (
+                self.active is not None
+                and self.active.is_connected()
+            ):
+                return True, {}
+            return False, _fill_both("in_flight_switch_failed")
+
+        async with self._switch_lock:
+            self._switch_event.clear()
+            try:
+                if self._stopped:
+                    return False, _fill_both("stopped")
+                # Decision 28: disconnect any stale half-dead
+                # `self.active` before probing so it cannot
+                # compete with the new connection.
+                if self.active is not None:
+                    try:
+                        await asyncio.wait_for(
+                            self.active.disconnect(),
+                            timeout=STEP_TIMEOUT_S,
+                        )
+                    except asyncio.TimeoutError:
+                        _LOGGER.warning(
+                            "active.disconnect() timed out after"
+                            " %ss; proceeding",
+                            STEP_TIMEOUT_S,
+                        )
+                    self.active = None
+                # Decision 26: release the warm-standby keepalive
+                # before any probe so recovery does not fight its
+                # own socket on failover_host.
+                if self._keepalive is not None:
+                    try:
+                        await asyncio.wait_for(
+                            self._keepalive.stop(),
+                            timeout=STEP_TIMEOUT_S,
+                        )
+                    except asyncio.TimeoutError:
+                        _LOGGER.warning(
+                            "keepalive.stop() timed out after %ss;"
+                            " proceeding",
+                            STEP_TIMEOUT_S,
+                        )
+                    self._keepalive = None
+                # Deterministic candidate order.
+                candidates = [
+                    self.primary_host, self.failover_host,
+                ]
+                for target in candidates:
+                    if self._stopped:
+                        return False, _fill_both("stopped")
+                    if not await _tcp_probe(
+                        target, DEAKO_DEFAULT_PORT, PROBE_TIMEOUT,
+                    ):
+                        reasons[target] = "tcp_probe_failed"
+                        continue
+                    new_deako = await self._connect_with_retry(
+                        target,
+                    )
+                    if new_deako is None:
+                        if self._stopped:
+                            return False, _fill_both("stopped")
+                        reasons[target] = "connect_exhausted"
+                        continue
+                    # Success on this target.
+                    self.active = new_deako
+                    self._replay_callbacks(new_deako)
+                    other = (
+                        self.failover_host
+                        if target == self.primary_host
+                        else self.primary_host
+                    )
+                    self.primary_host = target
+                    self.failover_host = other
+                    try:
+                        await self._start_keepalive(other)
+                    # pylint: disable-next=broad-exception-caught
+                    except Exception as exc:
+                        _LOGGER.warning(
+                            "keepalive start on %s failed after "
+                            "recovery: %s; pool proceeds without "
+                            "warm standby",
+                            other, exc,
+                        )
+                        self._keepalive = None
+                    _LOGGER.info(
+                        "recovery succeeded: primary=%s "
+                        "failover=%s",
+                        self.primary_host, self.failover_host,
+                    )
+                    self._fire_on_failover_switch()
+                    return True, {}
+                return False, reasons
+            finally:
+                self._switch_event.set()
+
+    # ----- control_device send path ----------------------------
+
+    async def _ensure_primary_or_raise(self) -> None:
+        """Section 7.5: if no connected primary, run recovery.
+
+        Raises `NoSocketException` with the decision-25 message
+        on recovery failure. Called from `control_device` when
+        `self.active` is None or not connected.
+        """
+        if self._stopped:
+            raise NoSocketException("pool stopped")
+        if (
+            self.active is not None
+            and self.active.is_connected()
+        ):
+            return
+        success, reasons = await self._attempt_recovery()
+        if success:
+            return
+        msg = (
+            f"no primary after recovery: "
+            f"tried primary={self.primary_host} "
+            f"({reasons.get(self.primary_host, 'unknown')}), "
+            f"failover={self.failover_host} "
+            f"({reasons.get(self.failover_host, 'unknown')})"
+        )
+        _LOGGER.error(msg)
+        raise NoSocketException(msg)
+
+    async def control_device(
+        self, uuid: str, power: bool, dim: int | None = None,
+    ) -> None:
+        """Send a device control command through the active pool.
+
+        Section 7.4 hot-failover path plus section 7.5 no-primary
+        path. The pool calls `Deako._control_device_strict` (not
+        the public `control_device`) so it sees the raising
+        contract from decision 29 and can drive failover.
+
+        On `OSError` or `NoSocketException` from the active send,
+        performs exactly one `_switch_to_failover(failed_host=
+        self.primary_host)` and exactly one retry of the strict
+        send on the new active. If the switch returns False, or
+        the retry raises, raises `NoSocketException` naming the
+        host(s) attempted. Does not cascade into
+        `_attempt_recovery`; the next call enters section 7.5 and
+        runs recovery naturally.
+        """
+        if self._stopped:
+            raise NoSocketException("pool stopped")
+        # Section 7.5: no connected primary -> run recovery.
+        if (
+            self.active is None
+            or not self.active.is_connected()
+        ):
+            await self._ensure_primary_or_raise()
+        # Hot path: send via strict.
+        assert self.active is not None
+        failed_host = self.primary_host
+        try:
+            # pylint: disable-next=protected-access
+            await self.active._control_device_strict(
+                uuid, power, dim,
+            )
+            return
+        except OSError:
+            # NoSocketException subclasses OSError per decision 17.
+            _LOGGER.warning(
+                "control_device send failed on active primary "
+                "%s; switching to failover",
+                failed_host,
+            )
+        # Single switch attempt.
+        switched = await self._switch_to_failover(
+            failed_host=failed_host,
+        )
+        if not switched:
+            msg = (
+                f"control_device failed and failover switch "
+                f"failed; last active host was {failed_host}"
+            )
+            _LOGGER.error(msg)
+            raise NoSocketException(msg)
+        # Exactly one retry on the new active.
+        new_host = self.primary_host
+        assert self.active is not None
+        try:
+            # pylint: disable-next=protected-access
+            await self.active._control_device_strict(
+                uuid, power, dim,
+            )
+        except OSError as exc:
+            msg = (
+                f"control_device failed twice across failover: "
+                f"first active={failed_host}, "
+                f"second active={new_host}: {exc}"
+            )
+            _LOGGER.error(msg)
+            raise NoSocketException(msg) from exc

--- a/pydeako/deako/_connection_pool.py
+++ b/pydeako/deako/_connection_pool.py
@@ -376,18 +376,7 @@ class DeakoConnectionPool:
         # connect was in flight, discard the freshly connected Deako
         # rather than installing it on a pool the caller has already
         # terminated.
-        if self._stopped:
-            try:
-                await asyncio.wait_for(
-                    new_active.disconnect(),
-                    timeout=STEP_TIMEOUT_S,
-                )
-            except asyncio.TimeoutError:
-                _LOGGER.warning(
-                    "active.disconnect() timed out after %ss; "
-                    "proceeding",
-                    STEP_TIMEOUT_S,
-                )
+        if await self._discard_if_stopped(new_active):
             return
         # Primary is live. Latch started BEFORE best-effort keepalive
         # so a keepalive failure does not un-set it.
@@ -564,6 +553,59 @@ class DeakoConnectionPool:
         except asyncio.TimeoutError:
             return False
 
+    async def _discard_if_stopped(self, deako: Deako) -> bool:
+        """If the pool is stopped, disconnect ``deako`` and return True.
+
+        Used after an async connect returns to check whether stop()
+        ran while the connect was in flight. If so, the freshly
+        connected Deako is disconnected rather than installed.
+        """
+        if not self._stopped:
+            return False
+        try:
+            await asyncio.wait_for(
+                deako.disconnect(), timeout=STEP_TIMEOUT_S,
+            )
+        except asyncio.TimeoutError:
+            _LOGGER.warning(
+                "active.disconnect() timed out after %ss; "
+                "proceeding",
+                STEP_TIMEOUT_S,
+            )
+        return True
+
+    async def _teardown_keepalive(self) -> None:
+        """Stop and clear the keepalive socket with bounded timeout."""
+        if self._keepalive is not None:
+            try:
+                await asyncio.wait_for(
+                    self._keepalive.stop(),
+                    timeout=STEP_TIMEOUT_S,
+                )
+            except asyncio.TimeoutError:
+                _LOGGER.warning(
+                    "keepalive.stop() timed out after %ss; "
+                    "proceeding",
+                    STEP_TIMEOUT_S,
+                )
+            self._keepalive = None
+
+    async def _teardown_active(self) -> None:
+        """Disconnect and clear the active Deako with bounded timeout."""
+        if self.active is not None:
+            try:
+                await asyncio.wait_for(
+                    self.active.disconnect(),
+                    timeout=STEP_TIMEOUT_S,
+                )
+            except asyncio.TimeoutError:
+                _LOGGER.warning(
+                    "active.disconnect() timed out after %ss; "
+                    "proceeding",
+                    STEP_TIMEOUT_S,
+                )
+            self.active = None
+
     # ----- on_connection_lost hook -----------------------------
 
     def _on_active_connection_lost(self) -> None:
@@ -599,7 +641,67 @@ class DeakoConnectionPool:
 
     # ----- Switch and recovery ---------------------------------
 
-    # pylint: disable-next=too-many-return-statements,too-many-branches
+    async def _wait_for_in_flight_switch(
+        self, failed_host: str | None,
+    ) -> bool | None:
+        """Wait for an already-running switch to finish.
+
+        Returns the result (bool) if a switch was in flight, or
+        None if the lock was free and the caller should proceed.
+        """
+        if not self._switch_lock.locked():
+            return None
+        try:
+            await asyncio.wait_for(
+                self._switch_event.wait(),
+                timeout=SWITCH_WAIT_TIMEOUT_S,
+            )
+        except asyncio.TimeoutError:
+            return False
+        if failed_host is None:
+            return (
+                self.active is not None
+                and self.active.is_connected()
+            )
+        return self.primary_host != failed_host
+
+    async def _execute_failover_switch(self) -> bool:
+        """Core failover logic after guards pass. Lock must be held.
+
+        Tears down the current keepalive and active, waits for the
+        failover host to accept TCP, connects with retry, and
+        installs the new active on success.
+        """
+        # Release the standby keepalive before connecting. The
+        # bridge only accepts one TCP session, so the keepalive
+        # must be dropped first or it blocks the real Deako
+        # connection to the failover host.
+        await self._teardown_keepalive()
+        await self._teardown_active()
+        if self._stopped:
+            return False
+        target = self.failover_host
+        ready = await self._wait_ready(
+            target, timeout=BRIDGE_RECYCLE_TIMEOUT_S,
+        )
+        if not ready:
+            _LOGGER.warning(
+                "switch: host_not_ready on %s", target,
+            )
+            return False
+        new_active = await self._connect_with_retry(target)
+        if new_active is None:
+            _LOGGER.warning(
+                "switch: connect_exhausted on %s", target,
+            )
+            return False
+        if await self._discard_if_stopped(new_active):
+            return False
+        await self._install_new_active(
+            target, new_active, "failover switch",
+        )
+        return True
+
     async def _switch_to_failover(
         self, failed_host: str | None,
     ) -> bool:
@@ -619,128 +721,23 @@ class DeakoConnectionPool:
         otherwise by whether the primary has moved off
         `failed_host`.
         """
-        # Step 1: concurrent-caller path.
-        if self._switch_lock.locked():
-            try:
-                await asyncio.wait_for(
-                    self._switch_event.wait(),
-                    timeout=SWITCH_WAIT_TIMEOUT_S,
-                )
-            except asyncio.TimeoutError:
-                return False
-            if failed_host is None:
-                return (
-                    self.active is not None
-                    and self.active.is_connected()
-                )
-            return self.primary_host != failed_host
+        in_flight = await self._wait_for_in_flight_switch(
+            failed_host,
+        )
+        if in_flight is not None:
+            return in_flight
 
         async with self._switch_lock:
             self._switch_event.clear()
             try:
-                # Step 3: stale-host guard.
                 if (
                     failed_host is not None
                     and failed_host != self.primary_host
                 ):
                     return True
-                # Step 4: stopped check.
                 if self._stopped:
                     return False
-                # Release the standby keepalive before connecting.
-                # The bridge only accepts one TCP session, so the
-                # keepalive must be dropped first or it blocks the
-                # real Deako connection to the failover host.
-                if self._keepalive is not None:
-                    try:
-                        await asyncio.wait_for(
-                            self._keepalive.stop(),
-                            timeout=STEP_TIMEOUT_S,
-                        )
-                    except asyncio.TimeoutError:
-                        _LOGGER.warning(
-                            "keepalive.stop() timed out after %ss;"
-                            " proceeding",
-                            STEP_TIMEOUT_S,
-                        )
-                    self._keepalive = None
-                # Step 7: disconnect the failed active.
-                if self.active is not None:
-                    try:
-                        await asyncio.wait_for(
-                            self.active.disconnect(),
-                            timeout=STEP_TIMEOUT_S,
-                        )
-                    except asyncio.TimeoutError:
-                        _LOGGER.warning(
-                            "active.disconnect() timed out after"
-                            " %ss; proceeding",
-                            STEP_TIMEOUT_S,
-                        )
-                    self.active = None
-                # Step 8: stopped check.
-                if self._stopped:
-                    return False
-                # Step 9: wait for failover host to accept TCP.
-                target = self.failover_host
-                ready = await self._wait_ready(
-                    target, timeout=BRIDGE_RECYCLE_TIMEOUT_S,
-                )
-                if not ready:
-                    _LOGGER.warning(
-                        "switch: host_not_ready on %s", target,
-                    )
-                    return False
-                # Step 10: bounded connect-with-retry.
-                new_active = await self._connect_with_retry(target)
-                if new_active is None:
-                    _LOGGER.warning(
-                        "switch: connect_exhausted on %s", target,
-                    )
-                    return False
-                # Post-await stopped re-check. If stop() ran while
-                # _connect_with_retry was in flight, discard the
-                # freshly connected Deako and bail without mutating
-                # the host map.
-                if self._stopped:
-                    try:
-                        await asyncio.wait_for(
-                            new_active.disconnect(),
-                            timeout=STEP_TIMEOUT_S,
-                        )
-                    except asyncio.TimeoutError:
-                        _LOGGER.warning(
-                            "active.disconnect() timed out after"
-                            " %ss; proceeding",
-                            STEP_TIMEOUT_S,
-                        )
-                    return False
-                # Step 12: success. Swap host map, install new
-                # active, replay callbacks, start keepalive best
-                # effort on the former primary.
-                old_primary = self.primary_host
-                self.primary_host = target
-                self.failover_host = old_primary
-                self.active = new_active
-                self._replay_callbacks(new_active)
-                try:
-                    await self._start_keepalive(self.failover_host)
-                # pylint: disable-next=broad-exception-caught
-                except Exception as exc:
-                    _LOGGER.warning(
-                        "keepalive start on %s failed after "
-                        "switch: %s; pool proceeds without warm "
-                        "standby",
-                        self.failover_host, exc,
-                    )
-                    self._keepalive = None
-                _LOGGER.info(
-                    "failover switch succeeded: primary=%s "
-                    "failover=%s",
-                    self.primary_host, self.failover_host,
-                )
-                self._fire_on_failover_switch()
-                return True
+                return await self._execute_failover_switch()
             finally:
                 self._switch_event.set()
 
@@ -782,7 +779,104 @@ class DeakoConnectionPool:
                 "on_failover_switch callback error: %s", exc,
             )
 
-    # pylint: disable-next=too-many-return-statements,too-many-branches,too-many-statements
+    async def _install_new_active(
+        self, target: str, new_active: Deako, context: str,
+    ) -> None:
+        """Install a freshly connected Deako as the active.
+
+        Swaps the host roles so ``target`` becomes the new primary,
+        replays stored callbacks onto ``new_active``, and starts a
+        best-effort keepalive on the other host. ``context`` labels
+        log messages (e.g. ``"failover switch"`` or ``"recovery"``).
+        """
+        other = (
+            self.failover_host
+            if target == self.primary_host
+            else self.primary_host
+        )
+        self.primary_host = target
+        self.failover_host = other
+        self.active = new_active
+        self._replay_callbacks(new_active)
+        try:
+            await self._start_keepalive(other)
+        # pylint: disable-next=broad-exception-caught
+        except Exception as exc:
+            _LOGGER.warning(
+                "keepalive start on %s failed after "
+                "%s: %s; pool proceeds without warm "
+                "standby",
+                other, context, exc,
+            )
+            self._keepalive = None
+        _LOGGER.info(
+            "%s succeeded: primary=%s failover=%s",
+            context, self.primary_host, self.failover_host,
+        )
+        self._fire_on_failover_switch()
+
+    def _fill_both_reasons(
+        self, token: str,
+    ) -> dict[str, str]:
+        """Map both hosts to the same reason token."""
+        return {
+            self.primary_host: token,
+            self.failover_host: token,
+        }
+
+    async def _wait_for_in_flight_recovery(
+        self,
+    ) -> tuple[bool, dict[str, str]] | None:
+        """Wait for an already-running switch/recovery to finish.
+
+        Returns ``(bool, reasons)`` if a switch was in flight, or
+        None if the lock was free and the caller should proceed.
+        """
+        if not self._switch_lock.locked():
+            return None
+        try:
+            await asyncio.wait_for(
+                self._switch_event.wait(),
+                timeout=SWITCH_WAIT_TIMEOUT_S,
+            )
+        except asyncio.TimeoutError:
+            return False, self._fill_both_reasons(
+                "switch_wait_timeout",
+            )
+        if (
+            self.active is not None
+            and self.active.is_connected()
+        ):
+            return True, {}
+        return False, self._fill_both_reasons(
+            "in_flight_switch_failed",
+        )
+
+    async def _try_recovery_candidate(
+        self, target: str,
+    ) -> bool | str:
+        """Probe and connect to a single candidate during recovery.
+
+        Returns True on success (new active installed), False if the
+        pool was stopped mid-attempt, or a reason-token string on
+        failure (``"tcp_probe_failed"`` or ``"connect_exhausted"``).
+        """
+        if not await _tcp_probe(
+            target, DEAKO_DEFAULT_PORT, PROBE_TIMEOUT,
+        ):
+            return "tcp_probe_failed"
+        new_deako = await self._connect_with_retry(target)
+        if new_deako is None:
+            if self._stopped:
+                return False
+            return "connect_exhausted"
+        if await self._discard_if_stopped(new_deako):
+            return False
+        await self._install_new_active(
+            target, new_deako, "recovery",
+        )
+        return True
+
     async def _attempt_recovery(
         self,
     ) -> tuple[bool, dict[str, str]]:
@@ -799,132 +893,41 @@ class DeakoConnectionPool:
         `self.failover_host` second. The winner becomes the new
         active; the loser becomes the warm standby.
         """
-        reasons: dict[str, str] = {}
-
-        def _fill_both(token: str) -> dict[str, str]:
-            return {
-                self.primary_host: token,
-                self.failover_host: token,
-            }
-
-        # Concurrent-caller path.
-        if self._switch_lock.locked():
-            try:
-                await asyncio.wait_for(
-                    self._switch_event.wait(),
-                    timeout=SWITCH_WAIT_TIMEOUT_S,
-                )
-            except asyncio.TimeoutError:
-                return False, _fill_both("switch_wait_timeout")
-            if (
-                self.active is not None
-                and self.active.is_connected()
-            ):
-                return True, {}
-            return False, _fill_both("in_flight_switch_failed")
+        in_flight = await self._wait_for_in_flight_recovery()
+        if in_flight is not None:
+            return in_flight
 
         async with self._switch_lock:
             self._switch_event.clear()
             try:
                 if self._stopped:
-                    return False, _fill_both("stopped")
-                # Disconnect any stale half-dead `self.active`
-                # before probing so it cannot compete with the
-                # new connection.
-                if self.active is not None:
-                    try:
-                        await asyncio.wait_for(
-                            self.active.disconnect(),
-                            timeout=STEP_TIMEOUT_S,
-                        )
-                    except asyncio.TimeoutError:
-                        _LOGGER.warning(
-                            "active.disconnect() timed out after"
-                            " %ss; proceeding",
-                            STEP_TIMEOUT_S,
-                        )
-                    self.active = None
-                # Release the standby keepalive before probing. The
-                # bridge only accepts one TCP session, so recovery
-                # must not fight its own keepalive socket.
-                if self._keepalive is not None:
-                    try:
-                        await asyncio.wait_for(
-                            self._keepalive.stop(),
-                            timeout=STEP_TIMEOUT_S,
-                        )
-                    except asyncio.TimeoutError:
-                        _LOGGER.warning(
-                            "keepalive.stop() timed out after %ss;"
-                            " proceeding",
-                            STEP_TIMEOUT_S,
-                        )
-                    self._keepalive = None
-                # Deterministic candidate order.
-                candidates = [
+                    return False, self._fill_both_reasons("stopped")
+                # Disconnect stale active and release keepalive
+                # before probing. The bridge only accepts one TCP
+                # session, so recovery must not fight its own
+                # sockets.
+                await self._teardown_active()
+                await self._teardown_keepalive()
+                reasons: dict[str, str] = {}
+                for target in [
                     self.primary_host, self.failover_host,
-                ]
-                for target in candidates:
+                ]:
                     if self._stopped:
-                        return False, _fill_both("stopped")
-                    if not await _tcp_probe(
-                        target, DEAKO_DEFAULT_PORT, PROBE_TIMEOUT,
-                    ):
-                        reasons[target] = "tcp_probe_failed"
-                        continue
-                    new_deako = await self._connect_with_retry(
+                        return (
+                            False,
+                            self._fill_both_reasons("stopped"),
+                        )
+                    result = await self._try_recovery_candidate(
                         target,
                     )
-                    if new_deako is None:
-                        if self._stopped:
-                            return False, _fill_both("stopped")
-                        reasons[target] = "connect_exhausted"
-                        continue
-                    # Post-await stopped re-check. If stop() ran
-                    # while _connect_with_retry was in flight,
-                    # discard the freshly connected Deako and bail
-                    # without mutating the host map.
-                    if self._stopped:
-                        try:
-                            await asyncio.wait_for(
-                                new_deako.disconnect(),
-                                timeout=STEP_TIMEOUT_S,
-                            )
-                        except asyncio.TimeoutError:
-                            _LOGGER.warning(
-                                "active.disconnect() timed out "
-                                "after %ss; proceeding",
-                                STEP_TIMEOUT_S,
-                            )
-                        return False, _fill_both("stopped")
-                    # Success on this target.
-                    self.active = new_deako
-                    self._replay_callbacks(new_deako)
-                    other = (
-                        self.failover_host
-                        if target == self.primary_host
-                        else self.primary_host
-                    )
-                    self.primary_host = target
-                    self.failover_host = other
-                    try:
-                        await self._start_keepalive(other)
-                    # pylint: disable-next=broad-exception-caught
-                    except Exception as exc:
-                        _LOGGER.warning(
-                            "keepalive start on %s failed after "
-                            "recovery: %s; pool proceeds without "
-                            "warm standby",
-                            other, exc,
+                    if result is True:
+                        return True, {}
+                    if result is False:
+                        return (
+                            False,
+                            self._fill_both_reasons("stopped"),
                         )
-                        self._keepalive = None
-                    _LOGGER.info(
-                        "recovery succeeded: primary=%s "
-                        "failover=%s",
-                        self.primary_host, self.failover_host,
-                    )
-                    self._fire_on_failover_switch()
-                    return True, {}
+                    reasons[target] = result
                 return False, reasons
             finally:
                 self._switch_event.set()

--- a/pydeako/deako/_deako.py
+++ b/pydeako/deako/_deako.py
@@ -212,14 +212,15 @@ class Deako:
     ) -> None:
         """Add control request to queue.
 
-        Preserves 0.x external behavior per decision 29: any send
-        failure (no active connection, or OSError from the socket
-        layer) is caught here, logged at DEBUG, and swallowed so
-        HA callers see no observable change. The tuple
-        `(OSError, NoSocketException)` is retained deliberately
-        for explicitness even though NoSocketException is an
-        OSError subclass. Non-matching exceptions propagate
-        unchanged so programming errors remain visible.
+        Preserves existing public behavior: any send failure (no
+        active connection, or OSError from the socket layer) is
+        caught here, logged at DEBUG, and swallowed so HA callers
+        see no observable change. `_control_device_strict()` is
+        the raising path the pool uses to drive failover. The
+        tuple `(OSError, NoSocketException)` is retained for
+        explicitness even though NoSocketException is an OSError
+        subclass. Non-matching exceptions propagate unchanged so
+        programming errors remain visible.
         """
         try:
             await self._control_device_strict(uuid, power, dim)

--- a/pydeako/deako/_deako.py
+++ b/pydeako/deako/_deako.py
@@ -2,10 +2,11 @@
 import asyncio
 
 import logging
-from typing import Any
+from typing import Any, Callable
 
 from ..models import ResponseType
 from ._manager import _Manager
+from .utils._socket import NoSocketException
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
@@ -38,12 +39,27 @@ class Deako:
     devices: dict[str, Any]
     expected_devices: int
 
-    def __init__(self, get_address, client_name: str | None = None) -> None:
-        """Init manager for Deako local integration."""
+    def __init__(
+        self,
+        get_address,
+        client_name: str | None = None,
+        on_connection_lost: Callable | None = None,
+    ) -> None:
+        """Init manager for Deako local integration.
+
+        Args:
+            get_address: Async callable returning (address, name) tuple.
+            client_name: Optional client name sent in protocol messages.
+            on_connection_lost: Optional callback invoked by the
+                underlying _Manager when the connection drops (ping
+                timeout). Forwarded as-is so the connection pool can
+                hook failover on connection loss.
+        """
         self.connection_manager = _Manager(
             get_address,
             self.incoming_json,
             client_name=client_name,
+            on_connection_lost=on_connection_lost,
         )
         self.devices: dict[str, Any] = {}
         self.expected_devices = 0
@@ -170,17 +186,60 @@ class Deako:
                 f"{len(self.devices)}",
             )
 
-    async def control_device(
-        self, uuid: str, power: bool, dim: int | None = None
+    async def _control_device_strict(
+        self, uuid: str, power: bool, dim: int | None = None,
     ) -> None:
-        """Add control request to queue."""
+        """Strict control path consumed by the connection pool.
 
+        Raises NoSocketException when the underlying
+        send_state_change reports no active connection (False
+        return), and propagates OSError on a real send failure.
+        Not part of the public 0.x surface; the pool uses this to
+        drive failover on observed send failures. Public callers
+        should use control_device(), which preserves 0.x behavior.
+        """
         def completed_callback():
             self.update_state(uuid, power, dim)
 
-        await self.connection_manager.send_state_change(
-            uuid, power, dim, completed_callback=completed_callback
+        success = await self.connection_manager.send_state_change(
+            uuid, power, dim, completed_callback=completed_callback,
         )
+        if not success:
+            raise NoSocketException()
+
+    async def control_device(
+        self, uuid: str, power: bool, dim: int | None = None,
+    ) -> None:
+        """Add control request to queue.
+
+        Preserves 0.x external behavior per decision 29: any send
+        failure (no active connection, or OSError from the socket
+        layer) is caught here, logged at DEBUG, and swallowed so
+        HA callers see no observable change. The tuple
+        `(OSError, NoSocketException)` is retained deliberately
+        for explicitness even though NoSocketException is an
+        OSError subclass. Non-matching exceptions propagate
+        unchanged so programming errors remain visible.
+        """
+        try:
+            await self._control_device_strict(uuid, power, dim)
+        except (OSError, NoSocketException):
+            _LOGGER.debug(
+                "control_device send failed for %s; "
+                "swallowing per 0.x-compat contract",
+                uuid,
+            )
+
+    def is_connected(self) -> bool:
+        """Return True iff the underlying socket reports CONNECTED.
+
+        Thin public wrapper over the confirmed manager state. The
+        connection pool uses this instead of reaching into
+        connection_manager so the check stays a single supported
+        entry point on Deako.
+        """
+        conn = self.connection_manager.connection
+        return conn is not None and conn.is_connected()
 
     def get_name(self, uuid: str) -> str | None:
         """Get a device's name by uuid."""

--- a/pydeako/deako/_manager.py
+++ b/pydeako/deako/_manager.py
@@ -208,8 +208,7 @@ class _Manager:
 
         Returns True on successful enqueue, False only when there is no
         active connection. OSError from a real send failure propagates
-        to the caller so failover / the pool can act on it, per the
-        decision-17 send-failure contract.
+        to the caller so failover / the pool can act on it.
         """
         return await self.send_request(
             _Request(

--- a/pydeako/deako/_manager.py
+++ b/pydeako/deako/_manager.py
@@ -52,13 +52,29 @@ class _Manager:
         get_address,
         incoming_json_callback,
         client_name: str | None = None,
+        on_connection_lost: Callable | None = None,
     ) -> None:
-        """Initialize with get address function and incoming json callback."""
+        """Initialize with get address function and incoming json callback.
+
+        Args:
+            get_address: Async callable returning (address, name) tuple.
+            incoming_json_callback: Called with parsed JSON from the bridge.
+            client_name: Optional client name sent in protocol messages.
+            on_connection_lost: Optional callback invoked when the connection
+                drops (ping timeout). Called before auto-reconnect starts.
+        """
         self.get_address = get_address
         self.incoming_json_callback = incoming_json_callback
         self.pong_received = False
         self.tasks = set()
         self.client_name = client_name
+        self.on_connection_lost = on_connection_lost
+        # When False, every reconnect-scheduling call site is skipped
+        # (init_connection devices-not-found, init_connection connect
+        # timeout, maintain_connection_worker ping timeout). The pool
+        # disables this so failover owns reconnect, not _Manager.
+        # Default True preserves 0.x behavior for single-bridge callers.
+        self.auto_reconnect: bool = True
         self.state = _ManagerState()
 
     async def init_connection(self) -> None:
@@ -71,7 +87,8 @@ class _Manager:
             address, name = await self.get_address()
         except DevicesNotFoundException:
             _LOGGER.warning("No devices to connect to")
-            self.create_connection_task()
+            if self.auto_reconnect:
+                self.create_connection_task()
             self.state.connecting = False
             return
         connection = _Connection(address, name, self.incoming_json)
@@ -83,7 +100,8 @@ class _Manager:
             _LOGGER.error("Timeout attempting to connect. Trying again")
             self.state.connecting = False
             connection.close()
-            self.create_connection_task()
+            if self.auto_reconnect:
+                self.create_connection_task()
             return
         self.connection = connection
         # init connection watching
@@ -139,16 +157,30 @@ class _Manager:
                 break
             self.pong_received = False
             _LOGGER.debug("Pinging for responsiveness")
-            await self.send_request(
-                _Request(device_ping_request(source=self.client_name)),
-            )
+            try:
+                await self.send_request(
+                    _Request(device_ping_request(source=self.client_name)),
+                )
+            except OSError as exc:
+                # Send failure during health-check ping. Do not reraise;
+                # falling through with pong_received=False lets the
+                # "never received pong" branch below run the existing
+                # connection-drop path (on_connection_lost + close +
+                # reconnect under auto_reconnect).
+                _LOGGER.warning("Ping send failed: %s", exc)
             await asyncio.sleep(PING_WORKER_WAIT_S)
             if self.pong_received:
                 _LOGGER.debug("Pong received")
             else:
                 _LOGGER.warning("Never received pong! Dumping this connection")
+                if self.on_connection_lost is not None:
+                    try:
+                        self.on_connection_lost()
+                    except Exception:  # pylint: disable=broad-exception-caught
+                        _LOGGER.warning("on_connection_lost callback error")
                 self.close()
-                self.create_connection_task()
+                if self.auto_reconnect:
+                    self.create_connection_task()
                 break
 
     def incoming_json(self, incoming_json: dict) -> None:
@@ -171,9 +203,15 @@ class _Manager:
         power,
         dim=None,
         completed_callback: Callable | None = None,
-    ) -> None:
-        """Send a state change request."""
-        await self.send_request(
+    ) -> bool:
+        """Send a state change request.
+
+        Returns True on successful enqueue, False only when there is no
+        active connection. OSError from a real send failure propagates
+        to the caller so failover / the pool can act on it, per the
+        decision-17 send-failure contract.
+        """
+        return await self.send_request(
             _Request(
                 state_change_request(
                     uuid, power, dim, source=self.client_name,

--- a/pydeako/deako/test_connection_pool.py
+++ b/pydeako/deako/test_connection_pool.py
@@ -1,0 +1,1671 @@
+"""Tests for DeakoConnectionPool scaffold, lifecycle, switch,
+recovery, and control_device paths.
+
+Covers phase 6 of the failover work: module constants, `_tcp_probe`,
+`_KeepAliveSocket`, `ConnectionPoolState`, pool `__init__`, `state()`,
+`is_connected()`, `set_state_callback`, device accessors, `start()`
+fail-fast and keepalive best-effort, terminal re-entrant `stop()`,
+host-name invariants, `_switch_to_failover`, `_attempt_recovery`,
+and the section 7.4/7.5 `control_device` paths.
+"""
+# pylint: disable=too-many-lines
+
+import asyncio
+import dataclasses
+
+import pytest
+from mock import AsyncMock, MagicMock, Mock, patch
+
+from ._connection_pool import (
+    BRIDGE_RECYCLE_TIMEOUT_S,
+    ConnectionPoolState,
+    DEAKO_DEFAULT_PORT,
+    DeakoConnectionPool,
+    PROBE_TIMEOUT,
+    STEP_TIMEOUT_S,
+    SWITCH_CONNECT_BACKOFF_S,
+    SWITCH_CONNECT_RETRIES,
+    SWITCH_WAIT_TIMEOUT_S,
+    _KeepAliveSocket,
+    _tcp_probe,
+)
+from .utils._socket import NoSocketException
+
+
+# --- module constants ----------------------------------------------
+
+def test_module_constants_are_concrete():
+    """Module defines every constant used by the switch contracts."""
+    assert DEAKO_DEFAULT_PORT == 23
+    assert SWITCH_WAIT_TIMEOUT_S > 0
+    assert SWITCH_CONNECT_RETRIES == 3
+    assert SWITCH_CONNECT_BACKOFF_S == 1.0
+    assert BRIDGE_RECYCLE_TIMEOUT_S > 0
+    assert PROBE_TIMEOUT > 0
+    assert STEP_TIMEOUT_S == 2.0
+
+
+# --- _tcp_probe ----------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_tcp_probe_returns_true_on_open_connection():
+    """_tcp_probe succeeds when open_connection returns cleanly."""
+    writer = MagicMock()
+    writer.close = MagicMock()
+    writer.wait_closed = AsyncMock()
+    reader = MagicMock()
+    with patch(
+        "pydeako.deako._connection_pool.asyncio.open_connection",
+        new=AsyncMock(return_value=(reader, writer)),
+    ):
+        result = await _tcp_probe("10.0.0.1")
+    assert result is True
+    writer.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_tcp_probe_returns_false_on_oserror():
+    """_tcp_probe returns False when open_connection raises OSError."""
+    with patch(
+        "pydeako.deako._connection_pool.asyncio.open_connection",
+        new=AsyncMock(side_effect=OSError("refused")),
+    ):
+        result = await _tcp_probe("10.0.0.1")
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_tcp_probe_returns_false_on_timeout():
+    """_tcp_probe returns False when wait_for times out."""
+    async def slow_open(*_args, **_kwargs):
+        await asyncio.sleep(10)
+    with patch(
+        "pydeako.deako._connection_pool.asyncio.open_connection",
+        new=slow_open,
+    ):
+        result = await _tcp_probe("10.0.0.1", timeout=0.01)
+    assert result is False
+
+
+# --- _KeepAliveSocket ----------------------------------------------
+
+def test_keepalive_init_records_host_and_port():
+    """KeepAlive stores target coordinates without opening anything."""
+    ka = _KeepAliveSocket("10.0.0.1")
+    assert ka.host == "10.0.0.1"
+    assert ka.port == DEAKO_DEFAULT_PORT
+    assert ka.is_running() is False
+
+
+@pytest.mark.asyncio
+async def test_keepalive_start_opens_socket_and_marks_running():
+    """start() opens the inner socket and flips is_running True."""
+    ka = _KeepAliveSocket("10.0.0.1")
+    fake_sock = MagicMock()
+    fake_sock.connect_socket = AsyncMock()
+    fake_sock.sock = MagicMock()  # non-None after connect_socket
+    with patch(
+        "pydeako.deako._connection_pool._SocketConnection",
+        return_value=fake_sock,
+    ):
+        await ka.start()
+    fake_sock.connect_socket.assert_awaited_once()
+    assert ka.is_running() is True
+
+
+@pytest.mark.asyncio
+async def test_keepalive_start_propagates_oserror():
+    """start() re-raises OSError from connect_socket."""
+    ka = _KeepAliveSocket("10.0.0.1")
+    fake_sock = MagicMock()
+    fake_sock.connect_socket = AsyncMock(side_effect=OSError("boom"))
+    with patch(
+        "pydeako.deako._connection_pool._SocketConnection",
+        return_value=fake_sock,
+    ):
+        with pytest.raises(OSError):
+            await ka.start()
+    assert ka.is_running() is False
+
+
+@pytest.mark.asyncio
+async def test_keepalive_stop_is_awaitable():
+    """stop() is a coroutine; awaiting it closes the inner socket."""
+    ka = _KeepAliveSocket("10.0.0.1")
+    inner = MagicMock()
+    ka._socket = inner  # pylint: disable=protected-access
+    ka._running = True  # pylint: disable=protected-access
+    coro = ka.stop()
+    assert asyncio.iscoroutine(coro)
+    await coro
+    inner.close_socket.assert_called_once()
+    assert ka.is_running() is False
+
+
+@pytest.mark.asyncio
+async def test_keepalive_stop_is_idempotent():
+    """Second stop() is a no-op."""
+    ka = _KeepAliveSocket("10.0.0.1")
+    await ka.stop()
+    await ka.stop()
+    assert ka.is_running() is False
+
+
+# --- ConnectionPoolState -------------------------------------------
+
+def test_connection_pool_state_fields():
+    """State has exactly the five fields in decision 23, no more."""
+    field_names = {f.name for f in dataclasses.fields(ConnectionPoolState)}
+    assert field_names == {
+        "primary_host",
+        "failover_host",
+        "primary_connected",
+        "failover_keepalive_active",
+        "started",
+    }
+
+
+def test_connection_pool_state_is_frozen():
+    """ConnectionPoolState is frozen: assignment raises."""
+    s = ConnectionPoolState(
+        primary_host="10.0.0.1",
+        failover_host="10.0.0.2",
+        primary_connected=False,
+        failover_keepalive_active=False,
+        started=False,
+    )
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        s.primary_connected = True  # type: ignore[misc]
+
+
+# --- Pool __init__ and state ---------------------------------------
+
+def test_pool_init_stores_hosts_and_starts_unstarted():
+    """Init holds both host names and switch_event begins set."""
+    pool = DeakoConnectionPool(
+        primary_host="10.0.0.1", failover_host="10.0.0.2",
+    )
+    assert pool.primary_host == "10.0.0.1"
+    assert pool.failover_host == "10.0.0.2"
+    assert pool.active is None
+    # pylint: disable-next=protected-access
+    assert pool._keepalive is None
+    # pylint: disable-next=protected-access
+    assert pool._started is False
+    # pylint: disable-next=protected-access
+    assert pool._stopped is False
+
+
+def test_switch_event_set_on_init():
+    """`_switch_event` starts set so pre-switch waiters do not block."""
+    pool = DeakoConnectionPool(
+        primary_host="10.0.0.1", failover_host="10.0.0.2",
+    )
+    # pylint: disable-next=protected-access
+    assert pool._switch_event.is_set() is True
+
+
+def test_state_pre_start_reports_degraded():
+    """Before start(), state shows unconnected primary and no keepalive."""
+    pool = DeakoConnectionPool(
+        primary_host="10.0.0.1", failover_host="10.0.0.2",
+    )
+    s = pool.state()
+    assert s.primary_host == "10.0.0.1"
+    assert s.failover_host == "10.0.0.2"
+    assert s.primary_connected is False
+    assert s.failover_keepalive_active is False
+    assert s.started is False
+
+
+def test_is_connected_false_with_no_active():
+    """is_connected() is False when the pool has no active Deako."""
+    pool = DeakoConnectionPool(
+        primary_host="10.0.0.1", failover_host="10.0.0.2",
+    )
+    assert pool.is_connected() is False
+
+
+def test_is_connected_uses_deako_is_connected():
+    """is_connected() delegates to Deako.is_connected (decision 21)."""
+    pool = DeakoConnectionPool(
+        primary_host="10.0.0.1", failover_host="10.0.0.2",
+    )
+    active = MagicMock()
+    active.is_connected.return_value = True
+    pool.active = active
+    assert pool.is_connected() is True
+    active.is_connected.assert_called_once()
+
+
+# --- set_state_callback --------------------------------------------
+
+def test_set_state_callback_stores_on_pool():
+    """Callbacks are stored in the pool registry."""
+    pool = DeakoConnectionPool(
+        primary_host="10.0.0.1", failover_host="10.0.0.2",
+    )
+    cb = Mock()
+    pool.set_state_callback("uuid-a", cb)
+    # pylint: disable-next=protected-access
+    assert pool._state_callbacks["uuid-a"] is cb
+
+
+def test_set_state_callback_forwards_to_active_if_present():
+    """When active is set, set_state_callback also forwards to it."""
+    pool = DeakoConnectionPool(
+        primary_host="10.0.0.1", failover_host="10.0.0.2",
+    )
+    active = MagicMock()
+    pool.active = active
+    cb = Mock()
+    pool.set_state_callback("uuid-a", cb)
+    active.set_state_callback.assert_called_once_with("uuid-a", cb)
+
+
+def test_replay_callbacks_registers_all_on_new_deako():
+    """Replay installs every stored callback onto the new Deako."""
+    pool = DeakoConnectionPool(
+        primary_host="10.0.0.1", failover_host="10.0.0.2",
+    )
+    cb_a = Mock()
+    cb_b = Mock()
+    pool.set_state_callback("uuid-a", cb_a)
+    pool.set_state_callback("uuid-b", cb_b)
+    new_deako = MagicMock()
+    # pylint: disable-next=protected-access
+    pool._replay_callbacks(new_deako)
+    assert new_deako.set_state_callback.call_count >= 2
+
+
+# --- Device accessor proxies ---------------------------------------
+
+def test_get_devices_empty_when_no_active():
+    """get_devices returns {} when no active Deako."""
+    pool = DeakoConnectionPool(
+        primary_host="10.0.0.1", failover_host="10.0.0.2",
+    )
+    assert pool.get_devices() == {}
+
+
+def test_get_devices_proxies_to_active():
+    """get_devices proxies to the active connection."""
+    pool = DeakoConnectionPool(
+        primary_host="10.0.0.1", failover_host="10.0.0.2",
+    )
+    active = MagicMock()
+    active.get_devices.return_value = {"u": {}}
+    pool.active = active
+    assert pool.get_devices() == {"u": {}}
+
+
+def test_get_state_and_name_and_dimmable_proxy():
+    """get_state / get_name / is_dimmable proxy to active."""
+    pool = DeakoConnectionPool(
+        primary_host="10.0.0.1", failover_host="10.0.0.2",
+    )
+    assert pool.get_state("u") is None
+    assert pool.get_name("u") is None
+    assert pool.is_dimmable("u") is None
+    active = MagicMock()
+    active.get_state.return_value = {"power": True, "dim": 50}
+    active.get_name.return_value = "Kitchen"
+    active.is_dimmable.return_value = True
+    pool.active = active
+    assert pool.get_state("u") == {"power": True, "dim": 50}
+    assert pool.get_name("u") == "Kitchen"
+    assert pool.is_dimmable("u") is True
+
+
+# --- start() -------------------------------------------------------
+
+def _fake_deako_connected(connected: bool = True) -> MagicMock:
+    """Build a MagicMock that looks like a live Deako for the pool."""
+    deako = MagicMock()
+    deako.is_connected.return_value = connected
+    deako.connect = AsyncMock()
+    deako.find_devices = AsyncMock()
+    deako.disconnect = AsyncMock()
+    deako.set_state_callback = MagicMock()
+    deako.get_devices.return_value = {}
+    # Pool uses strict (decision 29); make it awaitable by default.
+    # pylint: disable-next=protected-access
+    deako._control_device_strict = AsyncMock()
+    # Mirror the connection_manager attribute used in
+    # _connect_primary when wiring auto_reconnect off.
+    deako.connection_manager = MagicMock()
+    deako.connection_manager.auto_reconnect = True
+    return deako
+
+
+@pytest.mark.asyncio
+async def test_start_connects_primary_and_starts_keepalive():
+    """Happy path: primary connects, keepalive on failover starts."""
+    pool = DeakoConnectionPool(
+        primary_host="10.0.0.1", failover_host="10.0.0.2",
+    )
+    new_active = _fake_deako_connected()
+    with patch(
+        "pydeako.deako._connection_pool.Deako",
+        return_value=new_active,
+    ):
+        with patch.object(
+            _KeepAliveSocket, "start", new=AsyncMock(),
+        ):
+            await pool.start()
+    assert pool.active is new_active
+    # pylint: disable-next=protected-access
+    assert pool._started is True
+    s = pool.state()
+    assert s.started is True
+    assert s.primary_connected is True
+
+
+@pytest.mark.asyncio
+async def test_start_raises_when_primary_unreachable():
+    """Fail-fast: primary connect raises and pool stays unstarted."""
+    pool = DeakoConnectionPool(
+        primary_host="10.0.0.1", failover_host="10.0.0.2",
+    )
+    broken = _fake_deako_connected(connected=False)
+    broken.connect = AsyncMock(side_effect=OSError("no route"))
+    with patch(
+        "pydeako.deako._connection_pool.Deako",
+        return_value=broken,
+    ):
+        with pytest.raises(NoSocketException):
+            await pool.start()
+    assert pool.active is None
+    # pylint: disable-next=protected-access
+    assert pool._started is False
+    # pylint: disable-next=protected-access
+    assert pool._keepalive is None
+
+
+@pytest.mark.asyncio
+async def test_failed_start_leaves_pool_unstarted():
+    """Failed start leaves _started False, active None, keepalive None."""
+    pool = DeakoConnectionPool(
+        primary_host="10.0.0.1", failover_host="10.0.0.2",
+    )
+    broken = _fake_deako_connected(connected=False)
+    broken.find_devices = AsyncMock(
+        side_effect=NoSocketException("no socket"),
+    )
+    with patch(
+        "pydeako.deako._connection_pool.Deako",
+        return_value=broken,
+    ):
+        with pytest.raises(NoSocketException):
+            await pool.start()
+    s = pool.state()
+    assert s.started is False
+    assert s.primary_connected is False
+    assert s.failover_keepalive_active is False
+
+
+@pytest.mark.asyncio
+async def test_start_retries_after_failed_start():
+    """A second start() after a failed first attempt may succeed."""
+    pool = DeakoConnectionPool(
+        primary_host="10.0.0.1", failover_host="10.0.0.2",
+    )
+    bad = _fake_deako_connected(connected=False)
+    bad.connect = AsyncMock(side_effect=OSError("down"))
+    good = _fake_deako_connected()
+    calls = {"n": 0}
+
+    def factory(*_args, **_kwargs):
+        calls["n"] += 1
+        return bad if calls["n"] == 1 else good
+
+    with patch(
+        "pydeako.deako._connection_pool.Deako", side_effect=factory,
+    ):
+        with pytest.raises(NoSocketException):
+            await pool.start()
+        with patch.object(
+            _KeepAliveSocket, "start", new=AsyncMock(),
+        ):
+            await pool.start()
+    # pylint: disable-next=protected-access
+    assert pool._started is True
+    assert pool.state().started is True
+
+
+@pytest.mark.asyncio
+async def test_start_is_idempotent():
+    """A second start() on a running pool is a no-op."""
+    pool = DeakoConnectionPool(
+        primary_host="10.0.0.1", failover_host="10.0.0.2",
+    )
+    active = _fake_deako_connected()
+    with patch(
+        "pydeako.deako._connection_pool.Deako", return_value=active,
+    ):
+        with patch.object(
+            _KeepAliveSocket, "start", new=AsyncMock(),
+        ) as ka_start:
+            await pool.start()
+            await pool.start()
+    # Deako factory may be called only during the first start; no
+    # second keepalive.start coroutine on the second call.
+    assert ka_start.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_start_succeeds_when_keepalive_start_fails():
+    """Keepalive failure at start is non-fatal (decision 27)."""
+    pool = DeakoConnectionPool(
+        primary_host="10.0.0.1", failover_host="10.0.0.2",
+    )
+    active = _fake_deako_connected()
+    with patch(
+        "pydeako.deako._connection_pool.Deako", return_value=active,
+    ):
+        with patch.object(
+            _KeepAliveSocket,
+            "start",
+            new=AsyncMock(side_effect=OSError("kaput")),
+        ):
+            await pool.start()
+    # pylint: disable-next=protected-access
+    assert pool._started is True
+    # pylint: disable-next=protected-access
+    assert pool._keepalive is None
+    s = pool.state()
+    assert s.primary_connected is True
+    assert s.failover_keepalive_active is False
+
+
+@pytest.mark.asyncio
+async def test_state_reflects_degraded_keepalive_after_failure():
+    """After a keepalive-start failure, state flags are correct."""
+    pool = DeakoConnectionPool(
+        primary_host="10.0.0.1", failover_host="10.0.0.2",
+    )
+    active = _fake_deako_connected()
+    with patch(
+        "pydeako.deako._connection_pool.Deako", return_value=active,
+    ):
+        with patch.object(
+            _KeepAliveSocket,
+            "start",
+            new=AsyncMock(side_effect=OSError("kaput")),
+        ):
+            await pool.start()
+    s = pool.state()
+    assert s.primary_connected is True
+    assert s.failover_keepalive_active is False
+    assert s.started is True
+
+
+# --- stop() --------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_stop_before_start_is_safe():
+    """stop() on a pool that never started completes without raising."""
+    pool = DeakoConnectionPool(
+        primary_host="10.0.0.1", failover_host="10.0.0.2",
+    )
+    await pool.stop()
+    # pylint: disable-next=protected-access
+    assert pool._stopped is True
+
+
+@pytest.mark.asyncio
+async def test_stop_is_reentrant():
+    """A second stop() is a no-op (no double-disconnect)."""
+    pool = DeakoConnectionPool(
+        primary_host="10.0.0.1", failover_host="10.0.0.2",
+    )
+    active = _fake_deako_connected()
+    pool.active = active
+    # pylint: disable-next=protected-access
+    pool._started = True
+    await pool.stop()
+    await pool.stop()
+    assert active.disconnect.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_stop_releases_event_waiters():
+    """Tasks parked on _switch_event.wait() wake after stop()."""
+    pool = DeakoConnectionPool(
+        primary_host="10.0.0.1", failover_host="10.0.0.2",
+    )
+    # pylint: disable-next=protected-access
+    pool._switch_event.clear()
+
+    async def waiter():
+        # pylint: disable-next=protected-access
+        await pool._switch_event.wait()
+        return "awake"
+
+    task = asyncio.create_task(waiter())
+    await asyncio.sleep(0)  # let waiter park
+    await pool.stop()
+    result = await asyncio.wait_for(task, timeout=1.0)
+    assert result == "awake"
+
+
+@pytest.mark.asyncio
+async def test_stop_tears_down_keepalive_and_active():
+    """stop() disconnects active and stops keepalive."""
+    pool = DeakoConnectionPool(
+        primary_host="10.0.0.1", failover_host="10.0.0.2",
+    )
+    active = _fake_deako_connected()
+    pool.active = active
+    # pylint: disable-next=protected-access
+    pool._started = True
+    keepalive = MagicMock()
+    keepalive.stop = AsyncMock()
+    # pylint: disable-next=protected-access
+    pool._keepalive = keepalive
+    await pool.stop()
+    active.disconnect.assert_awaited_once()
+    keepalive.stop.assert_awaited_once()
+    assert pool.active is None
+    # pylint: disable-next=protected-access
+    assert pool._keepalive is None
+
+
+@pytest.mark.asyncio
+async def test_stop_swallows_keepalive_stop_timeout():
+    """Hung keepalive.stop() is bounded by STEP_TIMEOUT_S and swallowed."""
+    pool = DeakoConnectionPool(
+        primary_host="10.0.0.1", failover_host="10.0.0.2",
+    )
+
+    async def hang():
+        await asyncio.sleep(30)
+
+    keepalive = MagicMock()
+    keepalive.stop = hang
+    # pylint: disable-next=protected-access
+    pool._keepalive = keepalive
+    with patch(
+        "pydeako.deako._connection_pool.asyncio.wait_for",
+        new=AsyncMock(side_effect=asyncio.TimeoutError()),
+    ):
+        await pool.stop()
+    # pylint: disable-next=protected-access
+    assert pool._stopped is True
+    # pylint: disable-next=protected-access
+    assert pool._keepalive is None
+
+
+@pytest.mark.asyncio
+async def test_stop_swallows_active_disconnect_timeout():
+    """Hung active.disconnect() is bounded and swallowed."""
+    pool = DeakoConnectionPool(
+        primary_host="10.0.0.1", failover_host="10.0.0.2",
+    )
+    active = _fake_deako_connected()
+    pool.active = active
+    # pylint: disable-next=protected-access
+    pool._started = True
+    with patch(
+        "pydeako.deako._connection_pool.asyncio.wait_for",
+        new=AsyncMock(side_effect=asyncio.TimeoutError()),
+    ):
+        await pool.stop()
+    assert pool.active is None
+
+
+@pytest.mark.asyncio
+async def test_start_after_stop_raises():
+    """start() after stop() raises RuntimeError (pool is single-use)."""
+    pool = DeakoConnectionPool(
+        primary_host="10.0.0.1", failover_host="10.0.0.2",
+    )
+    await pool.stop()
+    with pytest.raises(RuntimeError):
+        await pool.start()
+
+
+# --- Host-name invariants ------------------------------------------
+
+@pytest.mark.asyncio
+async def test_host_names_never_none_through_failure_paths():
+    """Failed start() path does not null out the host fields."""
+    pool = DeakoConnectionPool(
+        primary_host="10.0.0.1", failover_host="10.0.0.2",
+    )
+    broken = _fake_deako_connected(connected=False)
+    broken.connect = AsyncMock(side_effect=OSError("down"))
+    with patch(
+        "pydeako.deako._connection_pool.Deako", return_value=broken,
+    ):
+        with pytest.raises(NoSocketException):
+            await pool.start()
+    s = pool.state()
+    assert isinstance(s.primary_host, str) and s.primary_host
+    assert isinstance(s.failover_host, str) and s.failover_host
+
+
+@pytest.mark.asyncio
+async def test_host_names_never_none_after_stop():
+    """stop() preserves both host names on state()."""
+    pool = DeakoConnectionPool(
+        primary_host="10.0.0.1", failover_host="10.0.0.2",
+    )
+    await pool.stop()
+    s = pool.state()
+    assert s.primary_host == "10.0.0.1"
+    assert s.failover_host == "10.0.0.2"
+
+
+# --- Helpers for switch / recovery tests ---------------------------
+
+def _started_pool(
+    primary: str = "10.0.0.1",
+    failover: str = "10.0.0.2",
+    active_connected: bool = True,
+) -> tuple[DeakoConnectionPool, MagicMock, MagicMock]:
+    """Build a pool in the started state without running start()."""
+    pool = DeakoConnectionPool(
+        primary_host=primary, failover_host=failover,
+    )
+    active = _fake_deako_connected(connected=active_connected)
+    pool.active = active
+    # pylint: disable-next=protected-access
+    pool._started = True
+    keepalive = MagicMock()
+    keepalive.stop = AsyncMock()
+    keepalive.is_running.return_value = True
+    # pylint: disable-next=protected-access
+    pool._keepalive = keepalive
+    return pool, active, keepalive
+
+
+# --- _switch_event lifecycle ---------------------------------------
+
+@pytest.mark.asyncio
+async def test_switch_event_set_after_success():
+    """Event is re-set after a successful _switch_to_failover."""
+    pool, _active, _ka = _started_pool()
+    new_active = _fake_deako_connected()
+    with patch.object(pool, "_wait_ready", AsyncMock(return_value=True)):
+        with patch.object(
+            pool, "_connect_primary",
+            AsyncMock(return_value=new_active),
+        ):
+            with patch.object(
+                pool, "_start_keepalive", AsyncMock(),
+            ):
+                # pylint: disable-next=protected-access
+                ok = await pool._switch_to_failover(
+                    failed_host="10.0.0.1",
+                )
+    assert ok is True
+    # pylint: disable-next=protected-access
+    assert pool._switch_event.is_set() is True
+
+
+@pytest.mark.asyncio
+async def test_switch_event_set_after_failure():
+    """Event is re-set after a switch failure (host_not_ready)."""
+    pool, _active, _ka = _started_pool()
+    with patch.object(
+        pool, "_wait_ready", AsyncMock(return_value=False),
+    ):
+        # pylint: disable-next=protected-access
+        ok = await pool._switch_to_failover(failed_host="10.0.0.1")
+    assert ok is False
+    # pylint: disable-next=protected-access
+    assert pool._switch_event.is_set() is True
+
+
+@pytest.mark.asyncio
+async def test_switch_event_set_after_exception():
+    """Event is re-set even if the switch body raises."""
+    pool, _active, _ka = _started_pool()
+
+    async def boom(*_args, **_kwargs):
+        raise RuntimeError("boom")
+
+    with patch.object(pool, "_wait_ready", boom):
+        with pytest.raises(RuntimeError):
+            # pylint: disable-next=protected-access
+            await pool._switch_to_failover(failed_host="10.0.0.1")
+    # pylint: disable-next=protected-access
+    assert pool._switch_event.is_set() is True
+
+
+@pytest.mark.asyncio
+async def test_switch_event_set_on_stop():
+    """stop() sets _switch_event so parked waiters wake promptly."""
+    pool = DeakoConnectionPool(
+        primary_host="10.0.0.1", failover_host="10.0.0.2",
+    )
+    # pylint: disable-next=protected-access
+    pool._switch_event.clear()
+    await pool.stop()
+    # pylint: disable-next=protected-access
+    assert pool._switch_event.is_set() is True
+
+
+# --- _switch_to_failover direct paths ------------------------------
+
+@pytest.mark.asyncio
+async def test_switch_success_swaps_hosts():
+    """A successful switch swaps primary_host with failover_host."""
+    pool, _active, _ka = _started_pool(
+        primary="10.0.0.1", failover="10.0.0.2",
+    )
+    new_active = _fake_deako_connected()
+    with patch.object(pool, "_wait_ready", AsyncMock(return_value=True)):
+        with patch.object(
+            pool, "_connect_primary",
+            AsyncMock(return_value=new_active),
+        ):
+            with patch.object(
+                pool, "_start_keepalive", AsyncMock(),
+            ):
+                # pylint: disable-next=protected-access
+                ok = await pool._switch_to_failover(
+                    failed_host="10.0.0.1",
+                )
+    assert ok is True
+    assert pool.primary_host == "10.0.0.2"
+    assert pool.failover_host == "10.0.0.1"
+    assert pool.active is new_active
+
+
+@pytest.mark.asyncio
+async def test_switch_failure_preserves_host_mapping():
+    """A failed switch leaves the host map untouched."""
+    pool, _active, _ka = _started_pool(
+        primary="10.0.0.1", failover="10.0.0.2",
+    )
+    with patch.object(pool, "_wait_ready", AsyncMock(return_value=False)):
+        # pylint: disable-next=protected-access
+        ok = await pool._switch_to_failover(failed_host="10.0.0.1")
+    assert ok is False
+    assert pool.primary_host == "10.0.0.1"
+    assert pool.failover_host == "10.0.0.2"
+
+
+@pytest.mark.asyncio
+async def test_switch_retry_exhaustion():
+    """Connect-with-retry exhausts and the switch returns False."""
+    pool, _active, _ka = _started_pool()
+    with patch.object(pool, "_wait_ready", AsyncMock(return_value=True)):
+        with patch.object(
+            pool, "_connect_primary",
+            AsyncMock(side_effect=OSError("nope")),
+        ):
+            with patch.object(
+                pool, "_cleanup_partial_connect", AsyncMock(),
+            ):
+                # Fast-forward the retry backoff sleeps.
+                with patch(
+                    "pydeako.deako._connection_pool.asyncio.sleep",
+                    new=AsyncMock(),
+                ):
+                    # pylint: disable-next=protected-access
+                    ok = await pool._switch_to_failover(
+                        failed_host="10.0.0.1",
+                    )
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_switch_stops_target_keepalive_before_probe():
+    """Keepalive.stop() is awaited before _wait_ready runs."""
+    pool, _active, keepalive = _started_pool()
+    order: list[str] = []
+
+    async def fake_ka_stop():
+        order.append("keepalive.stop")
+
+    async def fake_wait_ready(_host, **_kwargs):
+        order.append("wait_ready")
+        return False
+
+    keepalive.stop = fake_ka_stop
+    with patch.object(pool, "_wait_ready", fake_wait_ready):
+        # pylint: disable-next=protected-access
+        await pool._switch_to_failover(failed_host="10.0.0.1")
+    assert order[0] == "keepalive.stop"
+    assert "wait_ready" in order
+
+
+@pytest.mark.asyncio
+async def test_switch_disconnects_old_primary_before_probe():
+    """active.disconnect() runs before _wait_ready is called."""
+    pool, active, _keepalive = _started_pool()
+    order: list[str] = []
+
+    async def fake_disconnect():
+        order.append("active.disconnect")
+
+    async def fake_wait_ready(_host, **_kwargs):
+        order.append("wait_ready")
+        return False
+
+    active.disconnect = fake_disconnect
+    with patch.object(pool, "_wait_ready", fake_wait_ready):
+        # pylint: disable-next=protected-access
+        await pool._switch_to_failover(failed_host="10.0.0.1")
+    idx_disc = order.index("active.disconnect")
+    idx_wait = order.index("wait_ready")
+    assert idx_disc < idx_wait
+
+
+@pytest.mark.asyncio
+async def test_switch_teardown_uses_step_timeout():
+    """keepalive.stop() and active.disconnect() are bounded."""
+    pool, active, keepalive = _started_pool()
+
+    async def hang_ka():
+        await asyncio.sleep(30)
+
+    async def hang_disc():
+        await asyncio.sleep(30)
+
+    keepalive.stop = hang_ka
+    active.disconnect = hang_disc
+    with patch(
+        "pydeako.deako._connection_pool.asyncio.wait_for",
+        new=AsyncMock(side_effect=asyncio.TimeoutError()),
+    ):
+        with patch.object(
+            pool, "_wait_ready", AsyncMock(return_value=False),
+        ):
+            # pylint: disable-next=protected-access
+            ok = await pool._switch_to_failover(failed_host="10.0.0.1")
+    # Even though both teardowns hung, the switch proceeded and
+    # returned False via host_not_ready without wedging.
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_switch_concurrent_callers_wait_on_event():
+    """Second caller waits on _switch_event and returns the outcome."""
+    pool, _active, _ka = _started_pool(
+        primary="10.0.0.1", failover="10.0.0.2",
+    )
+    gate = asyncio.Event()
+    new_active = _fake_deako_connected()
+
+    async def slow_wait_ready(_host, **_kwargs):
+        await gate.wait()
+        return True
+
+    with patch.object(pool, "_wait_ready", slow_wait_ready):
+        with patch.object(
+            pool, "_connect_primary",
+            AsyncMock(return_value=new_active),
+        ):
+            with patch.object(
+                pool, "_start_keepalive", AsyncMock(),
+            ):
+                first = asyncio.create_task(
+                    # pylint: disable-next=protected-access
+                    pool._switch_to_failover(failed_host="10.0.0.1"),
+                )
+                await asyncio.sleep(0)  # let first take the lock
+                second = asyncio.create_task(
+                    # pylint: disable-next=protected-access
+                    pool._switch_to_failover(failed_host="10.0.0.1"),
+                )
+                await asyncio.sleep(0)  # let second park
+                gate.set()
+                r1 = await first
+                r2 = await second
+    assert r1 is True
+    # Second caller sees primary has moved off failed_host.
+    assert r2 is True
+
+
+@pytest.mark.asyncio
+async def test_switch_failed_host_none_checks_connected_state():
+    """failed_host=None path returns actual connected state."""
+    pool, _active, _ka = _started_pool()
+    gate = asyncio.Event()
+    new_active = _fake_deako_connected()
+
+    async def slow_wait_ready(_host, **_kwargs):
+        await gate.wait()
+        return True
+
+    with patch.object(pool, "_wait_ready", slow_wait_ready):
+        with patch.object(
+            pool, "_connect_primary",
+            AsyncMock(return_value=new_active),
+        ):
+            with patch.object(
+                pool, "_start_keepalive", AsyncMock(),
+            ):
+                first = asyncio.create_task(
+                    # pylint: disable-next=protected-access
+                    pool._switch_to_failover(failed_host="10.0.0.1"),
+                )
+                await asyncio.sleep(0)
+                second = asyncio.create_task(
+                    # pylint: disable-next=protected-access
+                    pool._switch_to_failover(failed_host=None),
+                )
+                await asyncio.sleep(0)
+                gate.set()
+                r1 = await first
+                r2 = await second
+    assert r1 is True
+    assert r2 is True
+
+
+@pytest.mark.asyncio
+async def test_switch_failed_host_stale_guard():
+    """If failed_host != primary_host, the switch returns True as no-op."""
+    pool, active, _ka = _started_pool(
+        primary="10.0.0.1", failover="10.0.0.2",
+    )
+    # Pretend the switch has already happened; primary_host moved.
+    pool.primary_host = "10.0.0.2"
+    pool.failover_host = "10.0.0.1"
+    # pylint: disable-next=protected-access
+    ok = await pool._switch_to_failover(failed_host="10.0.0.1")
+    assert ok is True
+    # Old active is still in place; switch was a no-op.
+    assert pool.active is active
+
+
+@pytest.mark.asyncio
+async def test_switch_succeeds_when_new_keepalive_start_fails():
+    """Keepalive-start failure on the former primary is non-fatal."""
+    pool, _active, _ka = _started_pool(
+        primary="10.0.0.1", failover="10.0.0.2",
+    )
+    new_active = _fake_deako_connected()
+    with patch.object(pool, "_wait_ready", AsyncMock(return_value=True)):
+        with patch.object(
+            pool, "_connect_primary",
+            AsyncMock(return_value=new_active),
+        ):
+            with patch.object(
+                pool, "_start_keepalive",
+                AsyncMock(side_effect=OSError("ka boom")),
+            ):
+                # pylint: disable-next=protected-access
+                ok = await pool._switch_to_failover(
+                    failed_host="10.0.0.1",
+                )
+    assert ok is True
+    assert pool.primary_host == "10.0.0.2"
+    # pylint: disable-next=protected-access
+    assert pool._keepalive is None
+
+
+@pytest.mark.asyncio
+async def test_stop_cancels_in_flight_switch():
+    """An in-flight switch observes _stopped and bails out."""
+    pool, _active, _ka = _started_pool()
+
+    async def slow_wait_ready(_host, **_kwargs):
+        # Simulate the switch sleeping during the probe window so
+        # stop() can flip _stopped before the next await.
+        await asyncio.sleep(0.1)
+        return True
+
+    with patch.object(pool, "_wait_ready", slow_wait_ready):
+        with patch.object(
+            pool, "_connect_primary",
+            AsyncMock(return_value=_fake_deako_connected()),
+        ):
+            switch = asyncio.create_task(
+                # pylint: disable-next=protected-access
+                pool._switch_to_failover(failed_host="10.0.0.1"),
+            )
+            await asyncio.sleep(0)  # yield to let the switch start
+            await pool.stop()
+            ok = await switch
+    # The switch observed _stopped after the _wait_ready await and
+    # bailed out with False; stopped pools never declare success.
+    assert ok is False
+
+
+# --- _attempt_recovery ---------------------------------------------
+
+@pytest.mark.asyncio
+async def test_attempt_recovery_tries_primary_first_then_failover():
+    """Recovery probes primary first, then failover on miss."""
+    pool, _active, _ka = _started_pool(
+        primary="10.0.0.1", failover="10.0.0.2",
+    )
+    pool.active = None  # degraded
+    probed: list[str] = []
+
+    async def fake_probe(host, *_args, **_kwargs):
+        probed.append(host)
+        return False
+
+    with patch(
+        "pydeako.deako._connection_pool._tcp_probe",
+        new=fake_probe,
+    ):
+        # pylint: disable-next=protected-access
+        ok, reasons = await pool._attempt_recovery()
+    assert ok is False
+    assert probed == ["10.0.0.1", "10.0.0.2"]
+    assert reasons.get("10.0.0.1") == "tcp_probe_failed"
+    assert reasons.get("10.0.0.2") == "tcp_probe_failed"
+
+
+@pytest.mark.asyncio
+async def test_attempt_recovery_succeeds_when_only_primary_responds():
+    """Recovery picks primary when only primary responds."""
+    pool, _active, _ka = _started_pool(
+        primary="10.0.0.1", failover="10.0.0.2",
+    )
+    pool.active = None
+
+    async def fake_probe(host, *_args, **_kwargs):
+        return host == "10.0.0.1"
+
+    new_active = _fake_deako_connected()
+    with patch(
+        "pydeako.deako._connection_pool._tcp_probe",
+        new=fake_probe,
+    ):
+        with patch.object(
+            pool, "_connect_primary",
+            AsyncMock(return_value=new_active),
+        ):
+            with patch.object(
+                pool, "_start_keepalive", AsyncMock(),
+            ):
+                # pylint: disable-next=protected-access
+                ok, reasons = await pool._attempt_recovery()
+    assert ok is True
+    assert reasons == {}
+    assert pool.primary_host == "10.0.0.1"
+    assert pool.failover_host == "10.0.0.2"
+    assert pool.active is new_active
+
+
+@pytest.mark.asyncio
+async def test_attempt_recovery_succeeds_when_only_failover_responds():
+    """Recovery promotes the failover when only it responds."""
+    pool, _active, _ka = _started_pool(
+        primary="10.0.0.1", failover="10.0.0.2",
+    )
+    pool.active = None
+
+    async def fake_probe(host, *_args, **_kwargs):
+        return host == "10.0.0.2"
+
+    new_active = _fake_deako_connected()
+    with patch(
+        "pydeako.deako._connection_pool._tcp_probe",
+        new=fake_probe,
+    ):
+        with patch.object(
+            pool, "_connect_primary",
+            AsyncMock(return_value=new_active),
+        ):
+            with patch.object(
+                pool, "_start_keepalive", AsyncMock(),
+            ):
+                # pylint: disable-next=protected-access
+                ok, _reasons = await pool._attempt_recovery()
+    assert ok is True
+    # Hosts swapped; new primary is the responsive one.
+    assert pool.primary_host == "10.0.0.2"
+    assert pool.failover_host == "10.0.0.1"
+
+
+@pytest.mark.asyncio
+async def test_attempt_recovery_raises_when_neither_responds():
+    """Recovery returns False with per-host reasons on total failure."""
+    pool, _active, _ka = _started_pool(
+        primary="10.0.0.1", failover="10.0.0.2",
+    )
+    pool.active = None
+
+    async def fake_probe(*_args, **_kwargs):
+        return False
+
+    with patch(
+        "pydeako.deako._connection_pool._tcp_probe",
+        new=fake_probe,
+    ):
+        # pylint: disable-next=protected-access
+        ok, reasons = await pool._attempt_recovery()
+    assert ok is False
+    assert reasons == {
+        "10.0.0.1": "tcp_probe_failed",
+        "10.0.0.2": "tcp_probe_failed",
+    }
+
+
+@pytest.mark.asyncio
+async def test_attempt_recovery_stops_keepalive_before_probing():
+    """Keepalive.stop() is awaited before any TCP probe runs."""
+    pool, _active, keepalive = _started_pool()
+    pool.active = None
+    order: list[str] = []
+
+    async def fake_ka_stop():
+        order.append("keepalive.stop")
+
+    async def fake_probe(host, *_args, **_kwargs):
+        order.append(f"probe:{host}")
+        return False
+
+    keepalive.stop = fake_ka_stop
+    with patch(
+        "pydeako.deako._connection_pool._tcp_probe",
+        new=fake_probe,
+    ):
+        # pylint: disable-next=protected-access
+        await pool._attempt_recovery()
+    assert order[0] == "keepalive.stop"
+    assert any(entry.startswith("probe:") for entry in order[1:])
+
+
+@pytest.mark.asyncio
+async def test_attempt_recovery_disconnects_stale_active_before_probe():
+    """Stale active is disconnected before any probe runs."""
+    pool, active, _keepalive = _started_pool()
+    # Half-dead active: present but not connected.
+    active.is_connected.return_value = False
+    order: list[str] = []
+
+    async def fake_disconnect():
+        order.append("active.disconnect")
+
+    async def fake_probe(host, *_args, **_kwargs):
+        order.append(f"probe:{host}")
+        return False
+
+    active.disconnect = fake_disconnect
+    with patch(
+        "pydeako.deako._connection_pool._tcp_probe",
+        new=fake_probe,
+    ):
+        # pylint: disable-next=protected-access
+        await pool._attempt_recovery()
+    assert "active.disconnect" in order
+    disc_idx = order.index("active.disconnect")
+    probe_idx = next(
+        i for i, v in enumerate(order) if v.startswith("probe:")
+    )
+    assert disc_idx < probe_idx
+    assert pool.active is None
+
+
+@pytest.mark.asyncio
+async def test_recovery_succeeds_when_new_keepalive_start_fails():
+    """Recovery still returns True when new keepalive start raises."""
+    pool, _active, _ka = _started_pool()
+    pool.active = None
+
+    async def fake_probe(host, *_args, **_kwargs):
+        return host == "10.0.0.1"
+
+    with patch(
+        "pydeako.deako._connection_pool._tcp_probe",
+        new=fake_probe,
+    ):
+        with patch.object(
+            pool, "_connect_primary",
+            AsyncMock(return_value=_fake_deako_connected()),
+        ):
+            with patch.object(
+                pool, "_start_keepalive",
+                AsyncMock(side_effect=OSError("boom")),
+            ):
+                # pylint: disable-next=protected-access
+                ok, _reasons = await pool._attempt_recovery()
+    assert ok is True
+    # pylint: disable-next=protected-access
+    assert pool._keepalive is None
+
+
+# --- control_device ------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_control_device_after_stop_raises():
+    """control_device() after stop() raises NoSocketException."""
+    pool = DeakoConnectionPool(
+        primary_host="10.0.0.1", failover_host="10.0.0.2",
+    )
+    await pool.stop()
+    with pytest.raises(NoSocketException):
+        await pool.control_device("u", True, 100)
+
+
+@pytest.mark.asyncio
+async def test_control_device_sends_without_switch_when_active_healthy():
+    """Happy path: send succeeds, no switch, strict path called once."""
+    pool, active, _ka = _started_pool()
+    await pool.control_device("u", True, 100)
+    # pylint: disable-next=protected-access
+    active._control_device_strict.assert_awaited_once_with(
+        "u", True, 100,
+    )
+
+
+@pytest.mark.asyncio
+async def test_pool_uses_control_device_strict_not_public():
+    """Pool invokes _control_device_strict, not public control_device."""
+    pool, active, _ka = _started_pool()
+    await pool.control_device("u", True, 100)
+    active.control_device.assert_not_called()
+    # pylint: disable-next=protected-access
+    active._control_device_strict.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_control_device_triggers_switch_on_send_oserror():
+    """OSError from strict triggers one _switch_to_failover call."""
+    pool, active, _ka = _started_pool(
+        primary="10.0.0.1", failover="10.0.0.2",
+    )
+    # pylint: disable-next=protected-access
+    active._control_device_strict = AsyncMock(
+        side_effect=OSError("send broke"),
+    )
+    new_active = _fake_deako_connected()
+
+    async def switch_stub(**_kwargs):
+        # Simulate successful switch: host swap and new active.
+        pool.primary_host, pool.failover_host = (
+            pool.failover_host, pool.primary_host,
+        )
+        pool.active = new_active
+        return True
+
+    with patch.object(
+        pool, "_switch_to_failover", side_effect=switch_stub,
+    ) as switch_mock:
+        await pool.control_device("u", True, 100)
+    switch_mock.assert_called_once()
+    kwargs = switch_mock.call_args.kwargs
+    assert kwargs.get("failed_host") == "10.0.0.1"
+
+
+@pytest.mark.asyncio
+async def test_control_device_triggers_switch_on_send_nosocketexception():
+    """NoSocketException from strict also triggers one switch."""
+    pool, active, _ka = _started_pool()
+    # pylint: disable-next=protected-access
+    active._control_device_strict = AsyncMock(
+        side_effect=NoSocketException("no socket"),
+    )
+    new_active = _fake_deako_connected()
+
+    async def switch_stub(**_kwargs):
+        pool.primary_host, pool.failover_host = (
+            pool.failover_host, pool.primary_host,
+        )
+        pool.active = new_active
+        return True
+
+    with patch.object(
+        pool, "_switch_to_failover", side_effect=switch_stub,
+    ) as switch_mock:
+        await pool.control_device("u", True, 100)
+    switch_mock.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_control_device_retries_once_on_new_active_after_switch():
+    """After a successful switch, strict is called once on new active."""
+    pool, active, _ka = _started_pool(
+        primary="10.0.0.1", failover="10.0.0.2",
+    )
+    # pylint: disable-next=protected-access
+    active._control_device_strict = AsyncMock(
+        side_effect=OSError("send broke"),
+    )
+    new_active = _fake_deako_connected()
+
+    async def switch_stub(**_kwargs):
+        pool.primary_host, pool.failover_host = (
+            pool.failover_host, pool.primary_host,
+        )
+        pool.active = new_active
+        return True
+
+    with patch.object(
+        pool, "_switch_to_failover", side_effect=switch_stub,
+    ):
+        await pool.control_device("u", True, 100)
+    # pylint: disable-next=protected-access
+    new_active._control_device_strict.assert_awaited_once_with(
+        "u", True, 100,
+    )
+
+
+@pytest.mark.asyncio
+async def test_control_device_raises_when_retry_on_new_active_fails():
+    """Retry OSError after switch names both hosts in the message."""
+    pool, active, _ka = _started_pool(
+        primary="10.0.0.1", failover="10.0.0.2",
+    )
+    # pylint: disable-next=protected-access
+    active._control_device_strict = AsyncMock(
+        side_effect=OSError("first"),
+    )
+    new_active = _fake_deako_connected()
+    # pylint: disable-next=protected-access
+    new_active._control_device_strict = AsyncMock(
+        side_effect=OSError("second"),
+    )
+
+    async def switch_stub(**_kwargs):
+        pool.primary_host, pool.failover_host = (
+            pool.failover_host, pool.primary_host,
+        )
+        pool.active = new_active
+        return True
+
+    with patch.object(
+        pool, "_switch_to_failover", side_effect=switch_stub,
+    ):
+        with pytest.raises(NoSocketException) as excinfo:
+            await pool.control_device("u", True, 100)
+    msg = str(excinfo.value)
+    assert "10.0.0.1" in msg
+    assert "10.0.0.2" in msg
+
+
+@pytest.mark.asyncio
+async def test_control_device_raises_when_switch_fails_no_cascade():
+    """Switch returns False; _attempt_recovery is not invoked."""
+    pool, active, _ka = _started_pool(
+        primary="10.0.0.1", failover="10.0.0.2",
+    )
+    # pylint: disable-next=protected-access
+    active._control_device_strict = AsyncMock(
+        side_effect=OSError("broke"),
+    )
+    with patch.object(
+        pool, "_switch_to_failover", AsyncMock(return_value=False),
+    ):
+        with patch.object(
+            pool, "_attempt_recovery", AsyncMock(),
+        ) as rec_mock:
+            with pytest.raises(NoSocketException) as excinfo:
+                await pool.control_device("u", True, 100)
+    rec_mock.assert_not_called()
+    assert "10.0.0.1" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_control_device_next_call_runs_recovery_via_no_primary_path():
+    """After a failed switch, the next call enters section 7.5."""
+    pool, active, _ka = _started_pool(
+        primary="10.0.0.1", failover="10.0.0.2",
+    )
+    # pylint: disable-next=protected-access
+    active._control_device_strict = AsyncMock(
+        side_effect=OSError("broke"),
+    )
+    # Simulate the post-failure degraded state: no connected active.
+    pool.active = None
+    with patch.object(
+        pool, "_attempt_recovery",
+        AsyncMock(return_value=(False, {
+            "10.0.0.1": "tcp_probe_failed",
+            "10.0.0.2": "tcp_probe_failed",
+        })),
+    ) as rec_mock:
+        with pytest.raises(NoSocketException):
+            await pool.control_device("u", True, 100)
+    rec_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_control_device_triggers_recovery_when_no_primary():
+    """No-primary entry: _attempt_recovery is called, then send."""
+    pool, _active, _ka = _started_pool()
+    pool.active = None
+    new_active = _fake_deako_connected()
+
+    async def recover():
+        pool.active = new_active
+        return True, {}
+
+    with patch.object(
+        pool, "_attempt_recovery", side_effect=recover,
+    ) as rec_mock:
+        await pool.control_device("u", True, 100)
+    rec_mock.assert_awaited_once()
+    # pylint: disable-next=protected-access
+    new_active._control_device_strict.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_control_device_raises_when_no_primary_after_failed_recovery():
+    """Recovery failure surfaces NoSocketException with both hosts."""
+    pool, _active, _ka = _started_pool(
+        primary="10.0.0.1", failover="10.0.0.2",
+    )
+    pool.active = None
+    with patch.object(
+        pool, "_attempt_recovery",
+        AsyncMock(return_value=(False, {
+            "10.0.0.1": "tcp_probe_failed",
+            "10.0.0.2": "connect_exhausted",
+        })),
+    ):
+        with pytest.raises(NoSocketException) as excinfo:
+            await pool.control_device("u", True, 100)
+    msg = str(excinfo.value)
+    assert "10.0.0.1" in msg
+    assert "tcp_probe_failed" in msg
+    assert "10.0.0.2" in msg
+    assert "connect_exhausted" in msg
+
+
+# --- Decision-25 messages ------------------------------------------
+
+@pytest.mark.asyncio
+async def test_nosocketexception_message_includes_hosts_tried():
+    """The raised NoSocketException names both hosts and reasons."""
+    pool, _active, _ka = _started_pool(
+        primary="10.0.0.1", failover="10.0.0.2",
+    )
+    pool.active = None
+    with patch.object(
+        pool, "_attempt_recovery",
+        AsyncMock(return_value=(False, {
+            "10.0.0.1": "connect_exhausted",
+            "10.0.0.2": "tcp_probe_failed",
+        })),
+    ):
+        with pytest.raises(NoSocketException) as excinfo:
+            await pool.control_device("u", True, 100)
+    msg = str(excinfo.value)
+    assert "primary=10.0.0.1" in msg
+    assert "connect_exhausted" in msg
+    assert "failover=10.0.0.2" in msg
+    assert "tcp_probe_failed" in msg
+
+
+@pytest.mark.asyncio
+async def test_nosocketexception_message_on_switch_wait_timeout():
+    """Recovery's concurrent-wait timeout produces switch_wait_timeout."""
+    pool, _active, _ka = _started_pool()
+    pool.active = None
+
+    # Grab the lock and park.
+    with patch.object(
+        pool, "_wait_ready", AsyncMock(return_value=True),
+    ):
+        with patch.object(
+            pool, "_connect_primary",
+            AsyncMock(return_value=_fake_deako_connected()),
+        ):
+            with patch.object(
+                pool, "_start_keepalive", AsyncMock(),
+            ):
+                # Start a switch that never completes.
+                held = asyncio.Event()
+
+                async def held_wait_ready(_host, **_kwargs):
+                    held.set()
+                    await asyncio.sleep(30)
+                    return True
+
+                with patch.object(
+                    pool, "_wait_ready", held_wait_ready,
+                ):
+                    task = asyncio.create_task(
+                        # pylint: disable-next=protected-access
+                        pool._switch_to_failover(
+                            failed_host="10.0.0.1",
+                        ),
+                    )
+                    await held.wait()
+                    # Now call recovery via low-level path.
+                    with patch(
+                        "pydeako.deako._connection_pool."
+                        "SWITCH_WAIT_TIMEOUT_S",
+                        0.01,
+                    ):
+                        # pylint: disable-next=protected-access
+                        ok, reasons = await pool._attempt_recovery()
+                    task.cancel()
+                    try:
+                        await task
+                    # pylint: disable-next=broad-exception-caught
+                    except (asyncio.CancelledError, Exception):
+                        pass
+    assert ok is False
+    assert reasons.get(pool.primary_host) == "switch_wait_timeout"
+    assert reasons.get(pool.failover_host) == "switch_wait_timeout"
+
+
+@pytest.mark.asyncio
+async def test_nosocketexception_message_on_in_flight_switch_failed():
+    """Recovery waits for in-flight switch that yields no active."""
+    pool, _active, _ka = _started_pool()
+    pool.active = None
+
+    gate = asyncio.Event()
+
+    async def slow_wait_ready(_host, **_kwargs):
+        await gate.wait()
+        return False  # causes switch failure
+
+    with patch.object(pool, "_wait_ready", slow_wait_ready):
+        task = asyncio.create_task(
+            # pylint: disable-next=protected-access
+            pool._switch_to_failover(failed_host="10.0.0.1"),
+        )
+        await asyncio.sleep(0)  # let switch take the lock
+        recovery = asyncio.create_task(
+            # pylint: disable-next=protected-access
+            pool._attempt_recovery(),
+        )
+        await asyncio.sleep(0)  # let recovery park
+        gate.set()
+        _ = await task
+        ok, reasons = await recovery
+    assert ok is False
+    for host in (pool.primary_host, pool.failover_host):
+        assert reasons[host] == "in_flight_switch_failed"
+
+
+@pytest.mark.asyncio
+async def test_nosocketexception_message_on_stopped_mid_loop():
+    """Setting _stopped mid-recovery yields 'stopped' for both hosts."""
+    pool, _active, _ka = _started_pool()
+    pool.active = None
+
+    first_probe_done = asyncio.Event()
+
+    async def fake_probe(host, *_args, **_kwargs):
+        if host == "10.0.0.1":
+            first_probe_done.set()
+            # Let the test flip _stopped after the first probe.
+            await asyncio.sleep(0)
+            return False
+        return False
+
+    with patch(
+        "pydeako.deako._connection_pool._tcp_probe",
+        new=fake_probe,
+    ):
+        task = asyncio.create_task(
+            # pylint: disable-next=protected-access
+            pool._attempt_recovery(),
+        )
+        await first_probe_done.wait()
+        # pylint: disable-next=protected-access
+        pool._stopped = True
+        ok, reasons = await task
+    assert ok is False
+    assert reasons == {
+        "10.0.0.1": "stopped",
+        "10.0.0.2": "stopped",
+    }
+
+
+# --- _connect_primary partial-failure cleanup ----------------------
+
+@pytest.mark.asyncio
+async def test_connect_primary_partial_failure_cleanup():
+    """A failed _connect_primary leaves no partial Deako live."""
+    pool = DeakoConnectionPool(
+        primary_host="10.0.0.1", failover_host="10.0.0.2",
+    )
+    broken = _fake_deako_connected()
+    broken.find_devices = AsyncMock(side_effect=OSError("boom"))
+    with patch(
+        "pydeako.deako._connection_pool.Deako", return_value=broken,
+    ):
+        with pytest.raises(OSError):
+            # pylint: disable-next=protected-access
+            await pool._connect_primary("10.0.0.1")
+        # Partial deako is still tracked; cleanup clears it and
+        # disconnects the half-constructed object.
+        # pylint: disable-next=protected-access
+        assert pool._partial_deako is broken
+        # pylint: disable-next=protected-access
+        await pool._cleanup_partial_connect()
+    broken.disconnect.assert_awaited_once()
+    # pylint: disable-next=protected-access
+    assert pool._partial_deako is None
+
+
+# --- on_connection_lost hook ---------------------------------------
+
+@pytest.mark.asyncio
+async def test_on_connection_lost_schedules_switch():
+    """The sync hook schedules a _switch_to_failover task."""
+    pool, _active, _ka = _started_pool()
+    with patch.object(
+        pool, "_switch_to_failover", AsyncMock(return_value=True),
+    ) as switch_mock:
+        # pylint: disable-next=protected-access
+        pool._on_active_connection_lost()
+        # Let the scheduled task run.
+        await asyncio.sleep(0)
+        # Drain: the task is tracked in _on_lost_tasks.
+        # pylint: disable-next=protected-access
+        for task in list(pool._on_lost_tasks):
+            await task
+    switch_mock.assert_awaited_once()
+    assert (
+        switch_mock.call_args.kwargs.get("failed_host")
+        == pool.primary_host
+    )
+
+
+def test_on_connection_lost_noop_when_stopped():
+    """Hook is a no-op once the pool is stopped."""
+    pool = DeakoConnectionPool(
+        primary_host="10.0.0.1", failover_host="10.0.0.2",
+    )
+    # pylint: disable-next=protected-access
+    pool._stopped = True
+    # Does not raise; does not schedule anything.
+    # pylint: disable-next=protected-access
+    pool._on_active_connection_lost()

--- a/pydeako/deako/test_connection_pool.py
+++ b/pydeako/deako/test_connection_pool.py
@@ -1669,3 +1669,137 @@ def test_on_connection_lost_noop_when_stopped():
     # Does not raise; does not schedule anything.
     # pylint: disable-next=protected-access
     pool._on_active_connection_lost()
+
+
+# --- fix(pool): stop-race and same-host guards --------------------
+
+def test_init_rejects_same_host_primary_and_failover():
+    """Constructor rejects single-bridge configuration per docstring.
+
+    The pool docstring promises single-bridge pools are unsupported;
+    constructing one must raise ValueError rather than silently
+    returning a pool whose failover target equals its primary.
+    """
+    with pytest.raises(ValueError):
+        DeakoConnectionPool(
+            primary_host="10.0.0.1",
+            failover_host="10.0.0.1",
+        )
+
+
+@pytest.mark.asyncio
+async def test_start_discards_new_active_if_stopped_mid_connect():
+    """stop() during start()'s connect must not install late Deako.
+
+    If _connect_primary is in flight when stop() sets _stopped=True,
+    the freshly connected Deako returned after the await must be
+    disconnected and discarded, not installed on self.active.
+    """
+    pool = DeakoConnectionPool(
+        primary_host="10.0.0.1", failover_host="10.0.0.2",
+    )
+    new_active = _fake_deako_connected()
+    release = asyncio.Event()
+
+    async def blocked(_host):
+        await release.wait()
+        return new_active
+
+    with patch.object(
+        DeakoConnectionPool,
+        "_connect_primary",
+        new=AsyncMock(side_effect=blocked),
+    ):
+        start_task = asyncio.create_task(pool.start())
+        # Yield so start_task enters the connect await.
+        await asyncio.sleep(0)
+        await pool.stop()
+        release.set()
+        await start_task
+    assert pool.active is None
+    # pylint: disable-next=protected-access
+    assert pool._started is False
+    new_active.disconnect.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_switch_discards_new_active_if_stopped_mid_connect():
+    """stop() during _switch_to_failover must not install late Deako.
+
+    If _connect_with_retry is in flight when stop() sets _stopped,
+    the switch must disconnect the freshly connected Deako, return
+    False, and leave the host map untouched.
+    """
+    pool, _active, _ka = _started_pool(
+        primary="10.0.0.1", failover="10.0.0.2",
+    )
+    new_active = _fake_deako_connected()
+    release = asyncio.Event()
+
+    async def blocked(_host):
+        await release.wait()
+        return new_active
+
+    with patch.object(
+        pool, "_wait_ready", AsyncMock(return_value=True),
+    ):
+        with patch.object(
+            pool, "_connect_with_retry",
+            AsyncMock(side_effect=blocked),
+        ):
+            # pylint: disable-next=protected-access
+            switch_task = asyncio.create_task(
+                pool._switch_to_failover(failed_host="10.0.0.1"),
+            )
+            await asyncio.sleep(0)
+            await pool.stop()
+            release.set()
+            ok = await switch_task
+    assert ok is False
+    assert pool.active is None
+    assert pool.primary_host == "10.0.0.1"
+    assert pool.failover_host == "10.0.0.2"
+    new_active.disconnect.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_recovery_discards_new_active_if_stopped_mid_connect():
+    """stop() during _attempt_recovery must not install late Deako.
+
+    If _connect_with_retry is in flight when stop() sets _stopped,
+    recovery must disconnect the freshly connected Deako, return
+    (False, reasons) with "stopped" tokens, and leave host map alone.
+    """
+    pool, _active, _ka = _started_pool(
+        primary="10.0.0.1", failover="10.0.0.2",
+    )
+    new_deako = _fake_deako_connected()
+    release = asyncio.Event()
+
+    async def blocked(_host):
+        await release.wait()
+        return new_deako
+
+    with patch(
+        "pydeako.deako._connection_pool._tcp_probe",
+        new=AsyncMock(return_value=True),
+    ):
+        with patch.object(
+            pool, "_connect_with_retry",
+            AsyncMock(side_effect=blocked),
+        ):
+            # pylint: disable-next=protected-access
+            rec_task = asyncio.create_task(pool._attempt_recovery())
+            await asyncio.sleep(0)
+            await pool.stop()
+            release.set()
+            ok, reasons = await rec_task
+    assert ok is False
+    assert reasons == {
+        "10.0.0.1": "stopped",
+        "10.0.0.2": "stopped",
+    }
+    assert pool.active is None
+    assert pool.primary_host == "10.0.0.1"
+    assert pool.failover_host == "10.0.0.2"
+    new_deako.disconnect.assert_awaited()

--- a/pydeako/deako/test_deako.py
+++ b/pydeako/deako/test_deako.py
@@ -1,11 +1,13 @@
 """Test Deako"""
 
-import json
+import logging
 from uuid import uuid4
+import json
 import pytest
-from mock import ANY, Mock, patch
+from mock import ANY, AsyncMock, Mock, patch
 
 from ._deako import Deako, FindDevicesError
+from .utils._socket import NoSocketException
 
 
 @patch("pydeako.deako._deako._Manager")
@@ -17,9 +19,33 @@ def test_init(manager_mock):
     deako = Deako(get_address_mock, client_name=client_name)
 
     manager_mock.assert_called_once_with(
-        get_address_mock, deako.incoming_json, client_name=client_name
+        get_address_mock,
+        deako.incoming_json,
+        client_name=client_name,
+        on_connection_lost=None,
     )
     assert deako is not None
+
+
+@patch("pydeako.deako._deako._Manager")
+def test_on_connection_lost_forwarded_to_manager(manager_mock):
+    """Deako forwards on_connection_lost kwarg to the _Manager."""
+    get_address_mock = Mock()
+    client_name = Mock()
+    callback = Mock()
+
+    Deako(
+        get_address_mock,
+        client_name=client_name,
+        on_connection_lost=callback,
+    )
+
+    manager_mock.assert_called_once_with(
+        get_address_mock,
+        ANY,  # incoming_json bound method
+        client_name=client_name,
+        on_connection_lost=callback,
+    )
 
 
 def test_update_state_uuid_not_found():
@@ -466,3 +492,158 @@ async def test_get_dimmable(device_exists, dimmable):
         assert is_dimmable == dimmable
     else:
         assert is_dimmable is None
+
+
+# ---------------------------------------------------------------------------
+# Phase 5 coverage: two-layer control_device contract
+# (private _control_device_strict raises; public control_device preserves
+# 0.x behavior with a narrow catch), plus Deako.is_connected() wrapper.
+# ---------------------------------------------------------------------------
+
+
+@patch("pydeako.deako._deako._Manager")
+@pytest.mark.asyncio
+async def test_control_device_strict_raises_on_no_connection(manager_mock):
+    """_control_device_strict raises NoSocketException when there is no
+    active connection (send_state_change returned False)."""
+    manager_instance = manager_mock.return_value
+    manager_instance.send_state_change = AsyncMock(return_value=False)
+
+    deako = Deako(Mock())
+
+    with pytest.raises(NoSocketException):
+        # pylint: disable-next=protected-access
+        await deako._control_device_strict(
+            uuid="uuid-1", power=True, dim=None,
+        )
+
+    manager_instance.send_state_change.assert_called_once_with(
+        "uuid-1", True, None, completed_callback=ANY,
+    )
+
+
+@patch("pydeako.deako._deako._Manager")
+@pytest.mark.asyncio
+async def test_control_device_strict_propagates_send_oserror(manager_mock):
+    """_control_device_strict propagates OSError from a real send failure."""
+    manager_instance = manager_mock.return_value
+    manager_instance.send_state_change = AsyncMock(
+        side_effect=OSError("broken pipe"),
+    )
+
+    deako = Deako(Mock())
+
+    with pytest.raises(OSError):
+        # pylint: disable-next=protected-access
+        await deako._control_device_strict(
+            uuid="uuid-1", power=True, dim=None,
+        )
+
+
+@patch("pydeako.deako._deako._Manager")
+@pytest.mark.asyncio
+async def test_control_device_public_returns_none_on_no_connection(
+    manager_mock,
+):
+    """Public control_device swallows NoSocketException, returns None."""
+    manager_instance = manager_mock.return_value
+    manager_instance.send_state_change = AsyncMock(return_value=False)
+
+    deako = Deako(Mock())
+
+    result = await deako.control_device("uuid-1", True, None)
+
+    assert result is None
+
+
+@patch("pydeako.deako._deako._Manager")
+@pytest.mark.asyncio
+async def test_control_device_public_returns_none_on_send_oserror(
+    manager_mock,
+):
+    """Public control_device swallows OSError, returns None."""
+    manager_instance = manager_mock.return_value
+    manager_instance.send_state_change = AsyncMock(
+        side_effect=OSError("broken pipe"),
+    )
+
+    deako = Deako(Mock())
+
+    result = await deako.control_device("uuid-1", True, None)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_control_device_public_does_not_catch_unrelated_exceptions():
+    """Public control_device's catch is narrow: unrelated exceptions
+    (e.g. a ValueError from an upstream validation path) propagate
+    unchanged. Proves the wrapper is not a bare except Exception."""
+    deako = Deako(Mock())
+
+    with patch.object(
+        deako,
+        "_control_device_strict",
+        AsyncMock(side_effect=ValueError("bad uuid")),
+    ):
+        with pytest.raises(ValueError):
+            await deako.control_device("uuid-1", True, None)
+
+
+@patch("pydeako.deako._deako._Manager")
+@pytest.mark.asyncio
+async def test_control_device_public_logs_at_debug_on_failure(
+    manager_mock, caplog,
+):
+    """Public control_device logs send failures at DEBUG, not WARNING."""
+    manager_instance = manager_mock.return_value
+    manager_instance.send_state_change = AsyncMock(return_value=False)
+
+    deako = Deako(Mock())
+
+    caplog.set_level(logging.DEBUG, logger="pydeako.deako")
+
+    await deako.control_device("uuid-1", True, None)
+
+    debug_hits = [
+        record for record in caplog.records
+        if record.levelno == logging.DEBUG
+        and "control_device send failed" in record.message
+    ]
+    assert debug_hits, "expected a DEBUG log on swallowed failure"
+    # Nothing at WARNING or above for this path.
+    assert not any(
+        record.levelno >= logging.WARNING
+        and "control_device send failed" in record.message
+        for record in caplog.records
+    )
+
+
+def test_is_connected_no_connection():
+    """is_connected is False when connection_manager.connection is None."""
+    deako = Deako(Mock())
+    deako.connection_manager.connection = None
+
+    assert deako.is_connected() is False
+
+
+def test_is_connected_connection_not_connected():
+    """is_connected is False when the underlying _Connection reports False."""
+    deako = Deako(Mock())
+    connection_mock = Mock()
+    connection_mock.is_connected.return_value = False
+    deako.connection_manager.connection = connection_mock
+
+    assert deako.is_connected() is False
+    connection_mock.is_connected.assert_called_once()
+
+
+def test_is_connected_connected():
+    """is_connected is True only when the _Connection reports CONNECTED."""
+    deako = Deako(Mock())
+    connection_mock = Mock()
+    connection_mock.is_connected.return_value = True
+    deako.connection_manager.connection = connection_mock
+
+    assert deako.is_connected() is True
+    connection_mock.is_connected.assert_called_once()

--- a/pydeako/deako/test_manager.py
+++ b/pydeako/deako/test_manager.py
@@ -2,6 +2,8 @@
 Test the SocketConnection manager.
 """
 
+import logging
+
 import pytest
 from mock import AsyncMock, Mock, patch
 
@@ -325,3 +327,210 @@ async def test_send_request_no_connection(
     await manager.send_request(request_mock)
 
     connection_mock.send_data.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Phase 4 coverage: on_connection_lost callback, ping-send OSError guard,
+# send_state_change contract, and auto_reconnect gating of the three
+# create_connection_task() sites.
+# ---------------------------------------------------------------------------
+
+
+@patch("pydeako.deako._manager._Manager.close")
+@patch("pydeako.deako._manager._Manager.create_connection_task")
+@patch("pydeako.deako._manager.asyncio", autospec=True)
+@pytest.mark.asyncio
+async def test_maintain_connection_worker_invokes_on_connection_lost(
+    asyncio_mock, create_connection_mock, close_mock
+):
+    """on_connection_lost fires once on ping timeout, before reconnect."""
+    callback = Mock()
+
+    manager = _Manager(AsyncMock(), Mock(), on_connection_lost=callback)
+
+    await manager.maintain_connection_worker()
+
+    assert len(asyncio_mock.sleep.mock_calls) == 2
+    callback.assert_called_once()
+    close_mock.assert_called_once()
+    create_connection_mock.assert_called_once()
+
+
+@patch("pydeako.deako._manager._Manager.close")
+@patch("pydeako.deako._manager._Manager.create_connection_task")
+@patch("pydeako.deako._manager.asyncio", autospec=True)
+@pytest.mark.asyncio
+async def test_maintain_worker_callback_exception_swallowed(
+    asyncio_mock, create_connection_mock, close_mock, caplog,
+):
+    """Exceptions from on_connection_lost are caught, logged at WARNING."""
+    callback = Mock(side_effect=RuntimeError("callback boom"))
+
+    manager = _Manager(AsyncMock(), Mock(), on_connection_lost=callback)
+
+    caplog.set_level(logging.WARNING, logger="pydeako.deako")
+
+    await manager.maintain_connection_worker()
+
+    assert len(asyncio_mock.sleep.mock_calls) == 2
+    callback.assert_called_once()
+    close_mock.assert_called_once()
+    create_connection_mock.assert_called_once()
+    assert any(
+        record.levelno == logging.WARNING
+        and "on_connection_lost callback error" in record.message
+        for record in caplog.records
+    )
+
+
+@patch("pydeako.deako._manager._Manager.close")
+@patch("pydeako.deako._manager._Manager.create_connection_task")
+@patch("pydeako.deako._manager.asyncio", autospec=True)
+@pytest.mark.asyncio
+async def test_maintain_connection_worker_no_on_connection_lost(
+    asyncio_mock, create_connection_mock, close_mock
+):
+    """Ping timeout with no callback still closes and reconnects."""
+    manager = _Manager(AsyncMock(), Mock())
+
+    assert manager.on_connection_lost is None
+
+    await manager.maintain_connection_worker()
+
+    assert len(asyncio_mock.sleep.mock_calls) == 2
+    close_mock.assert_called_once()
+    create_connection_mock.assert_called_once()
+
+
+@patch("pydeako.deako._manager._Manager.close")
+@patch("pydeako.deako._manager._Manager.create_connection_task")
+@patch("pydeako.deako._manager._Manager.send_request")
+@patch("pydeako.deako._manager.asyncio", autospec=True)
+@pytest.mark.asyncio
+async def test_maintain_worker_handles_ping_send_oserror(
+    asyncio_mock, send_request_mock, create_connection_mock, close_mock,
+):
+    """Ping-send OSError is caught; worker falls through to no-pong branch."""
+    send_request_mock.side_effect = OSError("broken pipe")
+
+    manager = _Manager(AsyncMock(), Mock())
+
+    await manager.maintain_connection_worker()
+
+    assert len(asyncio_mock.sleep.mock_calls) == 2
+    send_request_mock.assert_called_once()
+    close_mock.assert_called_once()
+    create_connection_mock.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_send_state_change_returns_false_when_disconnected():
+    """send_state_change returns False only for missing connection."""
+    manager = _Manager(AsyncMock(), Mock())
+    manager.connection = None
+
+    result = await manager.send_state_change(
+        uuid="uuid-1", power=True, dim=None,
+    )
+
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_send_state_change_propagates_oserror_when_connected():
+    """Real send failure surfaces as OSError, not a silent False."""
+    connection_mock = AsyncMock()
+    connection_mock.send_data.side_effect = OSError("broken pipe")
+
+    manager = _Manager(AsyncMock(), Mock())
+    manager.connection = connection_mock
+
+    with pytest.raises(OSError):
+        await manager.send_state_change(
+            uuid="uuid-1", power=True, dim=None,
+        )
+
+
+@patch("pydeako.deako._manager._Manager.create_connection_task")
+@pytest.mark.asyncio
+async def test_no_reconnect_when_auto_reconnect_false_devices_not_found(
+    create_connection_mock,
+):
+    """auto_reconnect=False skips reconnect on DevicesNotFoundException."""
+    get_address = AsyncMock()
+    get_address.side_effect = DevicesNotFoundException()
+
+    manager = _Manager(get_address, Mock())
+    manager.auto_reconnect = False
+
+    await manager.init_connection()
+
+    create_connection_mock.assert_not_called()
+    assert manager.state.connecting is False
+
+
+@patch("pydeako.deako._manager._Manager.create_connection_task")
+@patch("pydeako.deako._manager._Connection")
+@patch("pydeako.deako._manager.asyncio", autospec=True)
+@pytest.mark.asyncio
+async def test_no_reconnect_when_auto_reconnect_false_connect_timeout(
+    asyncio_mock, connection_mock, create_connection_mock,
+):
+    """auto_reconnect=False skips reconnect at connect-timeout site."""
+    address, name = Mock(), Mock()
+    get_address = AsyncMock()
+    get_address.return_value = address, name
+
+    connection_mock_instance = connection_mock.return_value
+    connection_mock_instance.is_connected.return_value = False
+
+    manager = _Manager(get_address, Mock())
+    manager.auto_reconnect = False
+
+    await manager.init_connection()
+
+    connection_mock.assert_called_once_with(
+        address, name, manager.incoming_json,
+    )
+    assert asyncio_mock.sleep.call_count == CONNECTION_TIMEOUT_S
+    connection_mock_instance.close.assert_called_once()
+    create_connection_mock.assert_not_called()
+
+
+@patch("pydeako.deako._manager._Manager.close")
+@patch("pydeako.deako._manager._Manager.create_connection_task")
+@patch("pydeako.deako._manager.asyncio", autospec=True)
+@pytest.mark.asyncio
+async def test_no_reconnect_when_auto_reconnect_false_ping_timeout(
+    asyncio_mock, create_connection_mock, close_mock,
+):
+    """auto_reconnect=False skips reconnect at ping-timeout site."""
+    manager = _Manager(AsyncMock(), Mock())
+    manager.auto_reconnect = False
+
+    await manager.maintain_connection_worker()
+
+    assert len(asyncio_mock.sleep.mock_calls) == 2
+    close_mock.assert_called_once()
+    create_connection_mock.assert_not_called()
+
+
+@patch("pydeako.deako._manager._Manager.close")
+@patch("pydeako.deako._manager._Manager.create_connection_task")
+@patch("pydeako.deako._manager.asyncio", autospec=True)
+@pytest.mark.asyncio
+async def test_no_reconnect_auto_reconnect_false_ping_timeout_with_callback(
+    asyncio_mock, create_connection_mock, close_mock,
+):
+    """auto_reconnect=False fires callback and closes, but no reconnect."""
+    callback = Mock()
+
+    manager = _Manager(AsyncMock(), Mock(), on_connection_lost=callback)
+    manager.auto_reconnect = False
+
+    await manager.maintain_connection_worker()
+
+    assert len(asyncio_mock.sleep.mock_calls) == 2
+    callback.assert_called_once()
+    close_mock.assert_called_once()
+    create_connection_mock.assert_not_called()

--- a/pydeako/deako/utils/_connection.py
+++ b/pydeako/deako/utils/_connection.py
@@ -60,11 +60,12 @@ class _Connection:
     async def send_data(self, data_to_send: str) -> None:
         """Send data to socket.
 
-        Narrow catch: only OSError (which includes NoSocketException
-        via its OSError inheritance) is caught to flip state to ERROR
-        before re-raising. Other exceptions propagate unchanged, so
-        programming errors and unrelated failures surface normally.
-        Callers get OSError propagation on real send failure.
+        On send failure, state must flip to ERROR immediately so the
+        rest of the state machine (and higher-level callers like the
+        pool) see the failure without polling. The ``except OSError``
+        is intentionally narrow: TypeError, AttributeError, and other
+        programming errors should propagate as bugs, not be converted
+        into connection-state changes.
         """
         _LOGGER.debug("[%s] Sending data: %s", self.address, data_to_send)
         try:

--- a/pydeako/deako/utils/_connection.py
+++ b/pydeako/deako/utils/_connection.py
@@ -58,13 +58,21 @@ class _Connection:
         self.init_run()
 
     async def send_data(self, data_to_send: str) -> None:
-        """Send data to socket."""
+        """Send data to socket.
+
+        Narrow catch: only OSError (which includes NoSocketException
+        via its OSError inheritance) is caught to flip state to ERROR
+        before re-raising. Other exceptions propagate unchanged, so
+        programming errors and unrelated failures surface normally.
+        Callers get OSError propagation on real send failure.
+        """
         _LOGGER.debug("[%s] Sending data: %s", self.address, data_to_send)
         try:
             await self.socket.send_bytes(str.encode(data_to_send))
-        except Exception as exc:  # pylint: disable=broad-exception-caught
+        except OSError as exc:
             _LOGGER.error("Error sending data: %s", exc)
             self.state = ConnectionState.ERROR
+            raise
 
     async def read_socket(self) -> None:
         """Read data from socket."""

--- a/pydeako/deako/utils/_socket.py
+++ b/pydeako/deako/utils/_socket.py
@@ -10,8 +10,15 @@ _LOGGER: logging.Logger = logging.getLogger(__package__)
 _MAX_PACKET_SIZE_BYTES = 2048
 
 
-class NoSocketException(Exception):
-    """No socket to perform ops exception"""
+class NoSocketException(OSError):
+    """No socket to perform ops exception.
+
+    Subclasses OSError so callers can use a single narrow catch for
+    real send failures from the underlying socket layer (an OSError
+    from sock_sendall / sock_recv) and the "no socket at all" case
+    (NoSocketException raised by _SocketConnection when self.sock is
+    None).
+    """
 
 
 class _SocketConnection:
@@ -32,7 +39,7 @@ class _SocketConnection:
         self.sock.setblocking(False)
         _LOGGER.info("Connecting to %s", self.address)
         address, port = self.address.split(":")
-        await self.loop.sock_connect(self.sock, (address, port))
+        await self.loop.sock_connect(self.sock, (address, int(port)))
 
     def close_socket(self) -> None:
         """Close socket."""

--- a/pydeako/deako/utils/_socket.py
+++ b/pydeako/deako/utils/_socket.py
@@ -39,6 +39,7 @@ class _SocketConnection:
         self.sock.setblocking(False)
         _LOGGER.info("Connecting to %s", self.address)
         address, port = self.address.split(":")
+        # split() returns strings; sock_connect() expects an integer port.
         await self.loop.sock_connect(self.sock, (address, int(port)))
 
     def close_socket(self) -> None:

--- a/pydeako/deako/utils/test_connection.py
+++ b/pydeako/deako/utils/test_connection.py
@@ -6,7 +6,7 @@ import pytest
 from mock import AsyncMock, call, Mock, patch
 
 from ._connection import _Connection, ConnectionState, UnknownStateException
-from ._socket import _SocketConnection
+from ._socket import _SocketConnection, NoSocketException
 
 
 @patch("pydeako.deako.utils._connection.asyncio")
@@ -31,19 +31,21 @@ def test_init(init_run_mock, socket_connection_mock, asyncio_mock):
     init_run_mock.assert_called_once()
 
 
-@pytest.mark.parametrize("raise_error,", [True, False])
 @patch("pydeako.deako.utils._connection.asyncio")
 @patch(
     "pydeako.deako.utils._connection._SocketConnection",
     spec=_SocketConnection,
 )
 @pytest.mark.asyncio
-async def test_send_data(
+async def test_send_data_happy_path(
     socket_connection_mock,
     asyncio_mock,
-    raise_error,
 ):
-    """Test _Connection.send_data."""
+    """Test _Connection.send_data on a successful send.
+
+    No exception is raised, state is unchanged, and the encoded
+    bytes reach the socket layer.
+    """
     data = str(uuid4())
     data_bytes = str.encode(data)
     address, name = Mock(), Mock()
@@ -55,19 +57,91 @@ async def test_send_data(
     socket_connection_mock.assert_called_once_with(address, loop_mock)
     socket_connection_mock_instance = socket_connection_mock.return_value
 
-    if raise_error:
-        socket_connection_mock_instance.send_bytes.side_effect = Exception()
-
     await conn.send_data(data)
 
     socket_connection_mock_instance.send_bytes.assert_called_once_with(
         data_bytes
     )
-    assert (
-        conn.state == ConnectionState.ERROR
-        if raise_error
-        else ConnectionState.NOT_STARTED
+    assert conn.state == ConnectionState.NOT_STARTED
+
+
+@patch("pydeako.deako.utils._connection.asyncio")
+@patch(
+    "pydeako.deako.utils._connection._SocketConnection",
+    spec=_SocketConnection,
+)
+@pytest.mark.asyncio
+async def test_send_data_reraises_oserror(
+    socket_connection_mock,
+    asyncio_mock,
+):
+    """Test _Connection.send_data re-raises OSError.
+
+    Per the decision-17 send-failure contract: on OSError from the
+    underlying socket send, state flips to ERROR and the exception
+    propagates to the caller so _Manager.send_request can surface
+    it. Other exceptions are not covered here (see other tests).
+    """
+    data = str(uuid4())
+    data_bytes = str.encode(data)
+    address, name = Mock(), Mock()
+    loop_mock = Mock()
+    asyncio_mock.get_running_loop.return_value = loop_mock
+
+    conn = _Connection(address, name, Mock())
+
+    socket_connection_mock.assert_called_once_with(address, loop_mock)
+    socket_connection_mock_instance = socket_connection_mock.return_value
+
+    socket_connection_mock_instance.send_bytes.side_effect = OSError()
+
+    with pytest.raises(OSError):
+        await conn.send_data(data)
+
+    socket_connection_mock_instance.send_bytes.assert_called_once_with(
+        data_bytes
     )
+    assert conn.state == ConnectionState.ERROR
+
+
+@patch("pydeako.deako.utils._connection.asyncio")
+@patch(
+    "pydeako.deako.utils._connection._SocketConnection",
+    spec=_SocketConnection,
+)
+@pytest.mark.asyncio
+async def test_send_data_reraises_nosocketexception(
+    socket_connection_mock,
+    asyncio_mock,
+):
+    """Test _Connection.send_data re-raises NoSocketException.
+
+    Because NoSocketException now subclasses OSError (decision 17),
+    the same narrow `except OSError:` in send_data catches and
+    re-raises it. State flips to ERROR.
+    """
+    data = str(uuid4())
+    data_bytes = str.encode(data)
+    address, name = Mock(), Mock()
+    loop_mock = Mock()
+    asyncio_mock.get_running_loop.return_value = loop_mock
+
+    conn = _Connection(address, name, Mock())
+
+    socket_connection_mock.assert_called_once_with(address, loop_mock)
+    socket_connection_mock_instance = socket_connection_mock.return_value
+
+    socket_connection_mock_instance.send_bytes.side_effect = (
+        NoSocketException()
+    )
+
+    with pytest.raises(NoSocketException):
+        await conn.send_data(data)
+
+    socket_connection_mock_instance.send_bytes.assert_called_once_with(
+        data_bytes
+    )
+    assert conn.state == ConnectionState.ERROR
 
 
 @pytest.mark.parametrize("raise_read_error", [True, False])

--- a/pydeako/deako/utils/test_socket.py
+++ b/pydeako/deako/utils/test_socket.py
@@ -9,6 +9,20 @@ import pytest
 from ._socket import _SocketConnection, NoSocketException
 
 
+def test_no_socket_exception_is_oserror_subclass():
+    """NoSocketException inherits from OSError (decision 17).
+
+    A single narrow `except OSError:` covers both a real socket
+    send failure and the 'no socket at all' sentinel. This is the
+    one externally observable widening in this PR: any
+    `except OSError:` that previously did not match
+    NoSocketException will now match it.
+    """
+    assert issubclass(NoSocketException, OSError)
+    # Instance check too, since mocks often raise the instance form.
+    assert isinstance(NoSocketException(), OSError)
+
+
 def test_init():
     """Test _SocketConnection.__init__."""
     address = str(uuid4())
@@ -27,7 +41,7 @@ def test_init():
 async def test_connect_socket(socket_mock):
     """Test _SocketConnection.connect_socket."""
     address = str(uuid4())
-    port = str(uuid4())
+    port = "23"
     full_address = f"{address}:{port}"
     loop_mock = AsyncMock()
 
@@ -40,7 +54,7 @@ async def test_connect_socket(socket_mock):
     )
     socket_mock.socket.return_value.setblocking.assert_called_once_with(False)
     loop_mock.sock_connect.assert_called_once_with(
-        socket_mock.socket.return_value, (address, port)
+        socket_mock.socket.return_value, (address, 23)
     )
 
 


### PR DESCRIPTION
## Summary

Adds `DeakoConnectionPool`, a thin supervisor over two `Deako`
instances that keeps one bridge as the active primary and the
other warm as a failover standby. Failover is triggered by two
paths into a single coordinator inside the pool: `_Manager`'s
ping loop (via the new `on_connection_lost` callback) and a
failed send inside `control_device`. There is no parallel
in-pool health monitor.

## What is new, public-facing

- `pydeako.DeakoConnectionPool`: high-level pool with `start()`,
  `stop()`, `control_device()`, `set_state_callback()`, `state()`.
- `pydeako.ConnectionPoolState`: frozen dataclass snapshot.
- `pydeako.NoSocketException`: `OSError` subclass raised by
  `_SocketConnection` when there is no live socket to send on.
- New kwarg on `Deako.__init__`: `on_connection_lost`.
- New helper: `Deako.is_connected()`.

## Externally observable behavior change

`NoSocketException` is a new exception class that subclasses
`OSError`. `_SocketConnection.send_bytes` and `read_bytes` now
raise it when there is no socket to operate on. Callers that
previously caught a different exception type for that condition
will see `NoSocketException` instead; catches on `OSError`
continue to work.

This is the only non-additive change in the PR.

## Key design points (round 2 changes)

- All `_AddressPool` changes reverted. The pool did not need
  non-destructive reads.
- `_KeepAliveSocket` composes `_SocketConnection`, so socket I/O
  stays in `utils/_socket.py`.
- No in-pool health monitor. `_Manager` pings. When a pong is
  missed, the pool's on-lost hook schedules one failover switch.
- Bridge readiness on the new primary is detected with a bounded
  TCP-probe poll, capped by a module-level timeout, rather than a
  blind sleep.
- `asyncio.Lock` + `asyncio.Event` coordinate the switch: the
  lock serializes, the event signals completion to in-flight
  callers so they either land on the new primary or fail cleanly
  on timeout.
- `ConnectionPoolState` is `frozen=True`.
- Idempotent `start()` / `stop()`.
- Sync state callbacks only in this PR.
- Module logger uses `__package__` to match the rest of the
  library.

## Version

Mostly additive public surface, with one narrow externally
observable change noted above (`NoSocketException` now subclasses
`OSError`). Leaving the version bump to maintainer discretion;
semver minor seems appropriate for the new surface, happy to bump
if you'd like me to.

## Companion HA integration PR

The `deako` integration in `home-assistant/core` is the first
consumer of the new public surface. The companion PR wires the
integration through `DeakoConnectionPool` and the new
`Deako.on_connection_lost` kwarg. The 250ms inter-command throttle
lives in the integration rather than the library, so pydeako stays
free of consumer-specific pacing. The HA PR is draft and will stay
draft until a pydeako release carrying this change is on PyPI.

Link: https://github.com/home-assistant/core/pull/167234

## Tests

- `pydeako/deako/test_manager.py`: coverage for the new
  `on_connection_lost` parameter (invocation on ping timeout,
  exception swallow, no-callback path).
- `pydeako/deako/test_deako.py`: coverage for the new parameter
  forwarding and for `is_connected()`.
- `pydeako/deako/test_connection_pool.py`: TCP probe behavior,
  keepalive socket lifecycle, `ConnectionPoolState` immutability,
  pool init validation, idempotent `start` / `stop`, switch
  coordination, readiness poll, full failover switch path (happy,
  stopped-early, host-not-ready, retry exhaustion, callback
  replay), and the `on_connection_lost` scheduling path.
- `pydeako/deako/utils/test_socket.py`,
  `pydeako/deako/utils/test_connection.py`: send-failure
  foundation and `NoSocketException` raising paths.

## Local gates run